### PR TITLE
Made congressman only load on attribute change

### DIFF
--- a/public/components/althingi-congressman.html
+++ b/public/components/althingi-congressman.html
@@ -1,3 +1,10 @@
+<!--
+    ALTHINGI-CONGRESSMAN-LIST
+    Paginated list of congressmen in alphabetic order.
+    This element will XHR request this list.
+
+    Self-contained, has no API or events.
+-->
 <dom-module is="althingi-congressman-list">
     <template>
         <althingi-pagination
@@ -16,6 +23,7 @@
     </template>
     <script>
         Polymer({
+
             is: 'althingi-congressman-list',
 
             properties: {
@@ -49,6 +57,14 @@
     </script>
 </dom-module>
 
+<!--
+    ALTHINGI-CONGRESSMAN-BADGE
+    Will request an image from althingi.is
+    but will not fetch any data via XHR.
+
+    @attribute name String Name of congressman
+    @attribute congressman Number ID of congressman
+-->
 <dom-module is="althingi-congressman-badge">
     <template>
         <iron-image style="width:60px; height:60px; background-color: lightgray;"
@@ -57,6 +73,7 @@
     </template>
     <script>
         Polymer({
+
             is: 'althingi-congressman-badge',
 
             properties: {
@@ -75,7 +92,7 @@
             },
 
             clickCongressmanGet: function () {
-                this.fire('congressman-get', this.congressman);
+                this.fire('congressman-get', {congressman: this.congressman});
             },
 
             computeUrl: function (congressman) {
@@ -86,15 +103,22 @@
     </script>
 </dom-module>
 
+<!--
+    ALTHINGI-CONGRESSMAN-PROFILE
+    This element, provided with an ID, will fetch
+    all kinds of information on congressman. It will
+    make all kinds of XHR requests.
+
+    @attribute congressman Number ID of congressman
+-->
 <dom-module is="althingi-congressman-profile">
     <template>
         <iron-ajax
                 url="{{url}}"
-                auto
                 on-response="handleResponse"
                 handle-as="json">
         </iron-ajax>
-        <article>
+        <article id="hero">
             <header>
                 <iron-image src="{{image}}"
                             style="width:100%; height: 400px; background-color: lightgray;"
@@ -125,17 +149,17 @@
     </template>
     <script>
         Polymer({
+
             is: 'althingi-congressman-profile',
 
             properties: {
                 congressman: {
                     type: Number,
-                    reflectToAttribute: true
+                    observer: 'changeProfile'
                 },
 
                 url: {
-                    type: String,
-                    computed: 'computeUrl(congressman)'
+                    type: String
                 },
 
                 data: {
@@ -143,21 +167,18 @@
                 },
 
                 image: {
-                    type: String,
-                    computed: 'computeImageUrl(data.congressman_id)'
+                    type: String
                 }
+            },
+
+            changeProfile: function (newValue, oldValue) {
+                this.url = '/api/thingmenn/' + newValue;
+                this.image = "http://althingi.is/myndir/mynd/thingmenn/"+newValue+"/org/mynd.jpg";
+                this.querySelector('iron-ajax').generateRequest();
             },
 
             handleResponse: function (event) {
                 this.data = event.detail.response;
-            },
-
-            computeUrl: function (congressman) {
-                return '/api/thingmenn/' + congressman;
-            },
-
-            computeImageUrl: function (congressman) {
-                return "http://althingi.is/myndir/mynd/thingmenn/"+congressman+"/org/mynd.jpg";
             }
         })
     </script>
@@ -165,11 +186,21 @@
 
 </dom-module>
 
+<!--
+    ALTHINGI-CONGRESSMAN-SESSION
+    Used within `althingi-congressman-profile` but can
+    be used as a stand-alone element.
+
+    Will fetch all sessions of a congressman.
+
+    Will XHR data.
+
+    @attribute congressman Number ID of congressman
+-->
 <dom-module is="althingi-congressman-sessions">
     <template>
         <iron-ajax
                 url="{{url}}"
-                auto
                 on-response="handleResponse"
                 handle-as="json">
         </iron-ajax>
@@ -186,16 +217,17 @@
     </template>
     <script>
         Polymer({
+
             is: 'althingi-congressman-sessions',
 
             properties: {
                 url: {
-                    type: String,
-                    computed: 'computeUrl(congressman)'
+                    type: String
                 },
 
                 congressman: {
-                    type: Number
+                    type: Number,
+                    observer: 'changeSession'
                 },
 
                 data: {
@@ -204,22 +236,33 @@
                 }
             },
 
-            handleResponse: function (event) {
-                this.data = event.detail.response
+            changeSession: function (newValue, oldValue) {
+                this.url = '/api/thingmenn/' + newValue +'/thingseta';
+                this.querySelector('iron-ajax').generateRequest();
             },
 
-            computeUrl: function (congressman) {
-                return '/api/thingmenn/' + congressman +'/thingseta';
+            handleResponse: function (event) {
+                this.data = event.detail.response
             }
         })
     </script>
 </dom-module>
 
+<!--
+    ALTHINGI-CONGRESSMAN-ISSUES
+    Used within `althingi-congressman-profile` but can
+    be used as a stand-alone element.
+
+    Fetches issues that congressman is foreman for.
+
+    Will XHR data.
+
+    @attribute congressman Number ID of congressman
+-->
 <dom-module is="althingi-congressman-issues">
     <template>
         <iron-ajax
                 url="{{url}}"
-                auto
                 on-response="handleResponse"
                 handle-as="json">
         </iron-ajax>
@@ -234,27 +277,28 @@
     </template>
     <script>
         Polymer({
+
             is: 'althingi-congressman-issues',
 
             properties: {
                 congressman: {
                     type: Number,
-                    reflectToAttribute: true
+                    observer: 'changeIssues'
                 },
 
                 url: {
-                    computed: 'computedUrl(congressman)'
+                    type: String
                 },
 
                 issues: {
                     type: Array,
                     value: []
                 }
-
             },
 
-            computedUrl: function (congressman) {
-                return '/api/thingmenn/'+congressman+'/thingmal'
+            changeIssues: function (newValue, oldValue) {
+                this.url = '/api/thingmenn/'+newValue+'/thingmal';
+                this.querySelector('iron-ajax').generateRequest();
             },
 
             handleResponse: function (event) {

--- a/public/components/althingi-congressman.html
+++ b/public/components/althingi-congressman.html
@@ -118,7 +118,7 @@
                 on-response="handleResponse"
                 handle-as="json">
         </iron-ajax>
-        <article id="hero">
+        <article>
             <header>
                 <iron-image src="{{image}}"
                             style="width:100%; height: 400px; background-color: lightgray;"

--- a/public/components/app.html
+++ b/public/components/app.html
@@ -5,6 +5,9 @@
 <link rel="import" href="../vendor/iron-icons/iron-icons.html">
 <link rel="import" href="../vendor/paper-spinner/paper-spinner.html">
 <link rel="import" href="../vendor/neon-animation/neon-animated-pages.html">
+<link rel="import" href="../vendor/neon-animation/neon-animations.html">
+<link rel="import" href="../vendor/neon-animation/neon-animatable.html">
+<link rel="import" href="../vendor/neon-animation/neon-shared-element-animatable-behavior.html">
 <link rel="import" href="../vendor/iron-image/iron-image.html">
 <link rel="import" href="../vendor/paper-header-panel/paper-header-panel.html">
 <link rel="import" href="../vendor/paper-icon-button/paper-icon-button.html">
@@ -26,13 +29,13 @@
         <paper-drawer-panel>
             <paper-header-panel drawer>
                 <paper-toolbar></paper-toolbar>
-                <div> Upcoming menu... </div>
+                <div>Menu coming soon...</div>
             </paper-header-panel>
             <paper-header-panel main>
                 <paper-toolbar>
                     <paper-fab mini icon="done" on-click="handleNavigateBegin"></paper-fab>
                 </paper-toolbar>
-                <neon-animated-pages id="pages" selected="0"
+                <neon-animated-pages id="pages" selected="0"  entry-animation="fade-in-animation" exit-animation="slide-left-animation"
                                      on-congressman-get="handleGetCongressman"
                                      on-plenaries-get="handleGetPlenaries"
                                      on-speeches-get="handleGetSpeeches"
@@ -41,6 +44,7 @@
                         <althingi-assembly-list></althingi-assembly-list>
                     </div>
                     <div></div>
+                    <althingi-congressman-profile></althingi-congressman-profile>
                     <div>
                         <!--althingi-speech-list assembly="144" issue="1"></althingi-speech-list-->
                         <!--althingi-congressman-profile congressman="704"></althingi-congressman-profile-->
@@ -78,11 +82,8 @@
             },
 
             handleGetCongressman: function (event) {
-                var issueContainer = document.createElement('althingi-congressman-profile');
-                issueContainer.setAttribute('congressman', event.detail);
-                this.$.pages.selected = 3;
-                this.$.pages.children[3].innerHTML = '';
-                this.$.pages.children[3].appendChild(issueContainer);
+                this.$.pages.selected = 2;
+                this.$.pages.children[2].setAttribute('congressman', event.detail.congressman);
             },
 
             handleGetSpeeches: function (event) {


### PR DESCRIPTION
To be able to reuse `althingi-congressman-profile` as a container element. The element shoud not try to load it's data if it does not have `congressman` attribute value.

If the `congressman` attribute value is changed, the the element has to be able to load all it's data.

This PR does that.

(it also adds small animation)