### PR TITLE
Adds hit/miss header to response

### DIFF
--- a/module/Althingi/Module.php
+++ b/module/Althingi/Module.php
@@ -31,6 +31,9 @@ class Module
 
             if ($event->getRequest()->getMethod() === HttpRequest::METHOD_GET && $cache->hasItem($storageKey)) {
                 $event->getApplication()->getEventManager()->clearListeners(MvcEvent::EVENT_DISPATCH);
+                $event->getResponse()->setHeaders((new \Zend\Http\Headers())->addHeaders([
+                    'X-Cache' => 'HIT'
+                ]));
                 $event->setViewModel(unserialize($cache->getItem($storageKey)));
             }
         });
@@ -44,6 +47,9 @@ class Module
             if ($event->getRequest()->getMethod() === HttpRequest::METHOD_GET &&
                 ! $cache->hasItem($storageKey) &&
                 $event->getResponse()->isSuccess()) {
+                $event->getResponse()->setHeaders((new \Zend\Http\Headers())->addHeaders([
+                    'X-Cache' => 'MISS'
+                ]));
                 $cache->addItem($storageKey, serialize($event->getResult()));
             }
         });

--- a/module/Althingi/Module.php
+++ b/module/Althingi/Module.php
@@ -2,70 +2,32 @@
 
 namespace Althingi;
 
+use Althingi\Utils\RequestCacheHandler;
+use Althingi\Utils\RequestErrorHandler;
 use Zend\Mvc\MvcEvent;
-use Rend\Event\ApplicationErrorHandler;
 use Rend\Event\ShutdownErrorHandler;
 use Zend\Cache\Storage\StorageInterface;
-use Zend\Http\Request as HttpRequest;
-use Zend\Http\PhpEnvironment\Request as PhpRequest;
 
 class Module
 {
     const VERSION = '3.0.3-dev';
 
-    public function onBootstrap(MvcEvent $e)
+    public function onBootstrap(MvcEvent $event)
     {
         register_shutdown_function(new ShutdownErrorHandler());
 
-        $cache = $e->getApplication()->getServiceManager()->get(StorageInterface::class);
+        $eventManager = $event->getApplication()
+            ->getEventManager();
+        $storageInterface = $event->getApplication()
+            ->getServiceManager()
+            ->get(StorageInterface::class);
 
-        $eventManager = $e->getApplication()->getEventManager();
+        (new RequestErrorHandler())
+            ->attach($eventManager);
 
-        $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, new ApplicationErrorHandler());
-
-        $eventManager->attach(MvcEvent::EVENT_ROUTE, function (MvcEvent $event) use ($cache) {
-            if ($event->getRequest() instanceof \Zend\Console\Request) {
-                return;
-            }
-            $storageKey = $this->storageKey($event->getRequest());
-
-            if ($event->getRequest()->getMethod() === HttpRequest::METHOD_GET && $cache->hasItem($storageKey)) {
-                $event->getApplication()->getEventManager()->clearListeners(MvcEvent::EVENT_DISPATCH);
-                $event->getResponse()->setHeaders((new \Zend\Http\Headers())->addHeaders([
-                    'X-Cache' => 'HIT'
-                ]));
-                $event->setViewModel(unserialize($cache->getItem($storageKey)));
-            }
-        });
-
-        $eventManager->attach(MvcEvent::EVENT_FINISH, function (MvcEvent $event) use ($cache) {
-            if ($event->getRequest() instanceof \Zend\Console\Request) {
-                return;
-            }
-            $storageKey = $this->storageKey($event->getRequest());
-
-            if ($event->getRequest()->getMethod() === HttpRequest::METHOD_GET &&
-                ! $cache->hasItem($storageKey) &&
-                $event->getResponse()->isSuccess()) {
-                $event->getResponse()->setHeaders((new \Zend\Http\Headers())->addHeaders([
-                    'X-Cache' => 'MISS'
-                ]));
-                $cache->addItem($storageKey, serialize($event->getResult()));
-            }
-        });
-    }
-
-    private function storageKey(PhpRequest $request)
-    {
-        /** @var  $path \Zend\Uri\Http*/
-        $uri = $request->getUri();
-        $query = $uri->getQueryAsArray();
-        ksort($query);
-
-        $range = $request->getHeaders()->has('Range')
-            ? $request->getHeaders()->get('Range')->getFieldValue()
-            : '';
-        return md5($uri->getPath() . $range . json_encode($query));
+        (new RequestCacheHandler())
+            ->setStorage($storageInterface)
+            ->attach($eventManager);
     }
 
     public function getConfig()

--- a/module/Althingi/src/Utils/RequestCacheHandler.php
+++ b/module/Althingi/src/Utils/RequestCacheHandler.php
@@ -1,0 +1,84 @@
+<?php
+namespace Althingi\Utils;
+
+use Althingi\Lib\CacheAwareInterface;
+use Zend\Cache\Storage\StorageInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\PhpEnvironment\Request as PhpRequest;
+use Zend\Mvc\MvcEvent;
+
+class RequestCacheHandler implements ListenerAggregateInterface, CacheAwareInterface
+{
+    /**
+     * @var \Zend\Cache\Storage\StorageInterface
+     */
+    private $storage;
+
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $cache = $this->storage;
+        $events->attach(MvcEvent::EVENT_ROUTE, function (MvcEvent $event) use ($cache) {
+            if ($event->getRequest() instanceof \Zend\Console\Request) {
+                return;
+            }
+            $storageKey = $this->storageKey($event->getRequest());
+
+            if ($event->getRequest()->getMethod() === HttpRequest::METHOD_GET && $cache->hasItem($storageKey)) {
+                $event->getApplication()->getEventManager()->clearListeners(MvcEvent::EVENT_DISPATCH);
+                $event->getResponse()->getHeaders()->addHeaderLine("X-Cache: HIT");
+                $event->setViewModel(unserialize($cache->getItem($storageKey)));
+            }
+        });
+        $events->attach(MvcEvent::EVENT_FINISH, function (MvcEvent $event) use ($cache) {
+            if ($event->getRequest() instanceof \Zend\Console\Request) {
+                return;
+            }
+            $storageKey = $this->storageKey($event->getRequest());
+
+            if ($event->getRequest()->getMethod() === HttpRequest::METHOD_GET
+                && ! $cache->hasItem($storageKey)
+                && $event->getResponse()->isSuccess()
+            ) {
+                $event->getResponse()->getHeaders()->addHeaderLine("X-Cache: MISS");
+                $cache->addItem($storageKey, serialize($event->getResult()));
+            }
+        });
+    }
+
+    public function detach(EventManagerInterface $events)
+    {
+        // TODO: Implement detach() method.
+    }
+
+    /**
+     * @param \Zend\Cache\Storage\StorageInterface $storage
+     * @return $this
+     */
+    public function setStorage(StorageInterface $storage)
+    {
+        $this->storage = $storage;
+        return $this;
+    }
+
+    /**
+     * @return \Zend\Cache\Storage\StorageInterface
+     */
+    public function getStorage()
+    {
+        return $this->storage;
+    }
+
+    private function storageKey(PhpRequest $request)
+    {
+        $uri = $request->getUri();
+        $query = $uri->getQueryAsArray();
+        ksort($query);
+
+        $range = $request->getHeaders()->has('Range')
+            ? $request->getHeaders()->get('Range')->getFieldValue()
+            : '';
+        return md5($uri->getPath() . $range . json_encode($query));
+    }
+}

--- a/module/Althingi/src/Utils/RequestErrorHandler.php
+++ b/module/Althingi/src/Utils/RequestErrorHandler.php
@@ -1,0 +1,20 @@
+<?php
+namespace Althingi\Utils;
+
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Mvc\MvcEvent;
+use Rend\Event\ApplicationErrorHandler;
+
+class RequestErrorHandler implements ListenerAggregateInterface
+{
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, new ApplicationErrorHandler());
+    }
+
+    public function detach(EventManagerInterface $events)
+    {
+        // TODO: Implement detach() method.
+    }
+}

--- a/module/Althingi/tests/Controller/CongressmanControllerTest.php
+++ b/module/Althingi/tests/Controller/CongressmanControllerTest.php
@@ -456,7 +456,7 @@ class CongressmanControllerTest extends AbstractHttpControllerTestCase
     {
         $this->getMockService(IssueCategory::class)
             ->shouldReceive('fetchFrequencyByAssemblyAndCongressman')
-            ->with(1, 2, null)
+            ->with(1, 2, ['A'])
             ->once()
             ->andReturn([new IssueCategoryAndTimeModel()])
             ->getMock();
@@ -505,7 +505,7 @@ class CongressmanControllerTest extends AbstractHttpControllerTestCase
 
         $this->getMockService(Congressman::class)
             ->shouldReceive('fetchTimeByAssembly')
-            ->with(1, null, 'desc', null)
+            ->with(1, null, 'desc', ['A'])
             ->once()
             ->andReturn([
                 (new \Althingi\Model\Congressman())->setCongressmanId(1)

--- a/module/Althingi/tests/Controller/IndexControllerTest.php
+++ b/module/Althingi/tests/Controller/IndexControllerTest.php
@@ -2,12 +2,8 @@
 
 namespace AlthingiTest\Controller;
 
-use AlthingiTest\ServiceHelper;
-use Mockery;
-use Althingi\Service\Committee;
-use Althingi\Model\Committee as CommitteeModel;
+use Zend\Cache\Storage\StorageInterface;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
-use Zend\Stdlib\ArrayUtils;
 
 /**
  * Class AssemblyCommitteeControllerTest
@@ -20,18 +16,9 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function setUp()
     {
-        // The module configuration should still be applicable for tests.
-        // You can override configuration here with test case specific values,
-        // such as sample view templates, path stacks, module_listener_options,
-        // etc.
-        $configOverrides = [];
-
-        $this->setApplicationConfig(ArrayUtils::merge(
-            // Grabbing the full application configuration:
-            include __DIR__ .'/../../../../config/application.config.php',
-            $configOverrides
-        ));
-        parent::setUp();
+        $this->setApplicationConfig(
+            include __DIR__ .'/../../../../config/application.config.php'
+        );
     }
 
     /**

--- a/module/Althingi/tests/Utils/RequestCacheHandlerTest.php
+++ b/module/Althingi/tests/Utils/RequestCacheHandlerTest.php
@@ -1,0 +1,255 @@
+<?php
+namespace AlthingiTest\Utils;
+
+use Althingi\Utils\RequestCacheHandler;
+use PHPUnit\Framework\TestCase;
+use Zend\Cache\Storage\Adapter\BlackHole;
+use Zend\Http\Headers;
+use Zend\Http\PhpEnvironment\Request;
+use Zend\Http\PhpEnvironment\Response;
+use Zend\Mvc\ApplicationInterface;
+use Zend\Mvc\MvcEvent;
+use Zend\Http\Request as HttpRequest;
+
+class RequestCacheHandlerTest extends TestCase
+{
+    /**
+     * MvcEvent::EVENT_ROUTE
+     * GET request
+     * Cache full
+     */
+    public function testMvcEventEventRouteHit()
+    {
+        $request = (new Request())->setMethod(HttpRequest::METHOD_GET);
+        $response = new Response();
+        $response->setHeaders(new Headers());
+
+        $eventManager = new \Zend\EventManager\EventManager();
+        $application = $this->getEmptyApplication();
+        $application->setRequest($request)
+            ->setResponse($response)
+            ->setEventManager($eventManager);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setResponse($response);
+        $event->setApplication($application);
+        $event->setName(MvcEvent::EVENT_ROUTE);
+
+        (new RequestCacheHandler())->setStorage($this->getPopulatedCache())->attach($eventManager);
+
+        $eventManager->triggerEvent($event);
+
+        $this->assertTrue($event->getResponse()->getHeaders()->has('X-Cache'));
+        $this->assertEquals('HIT', $event->getResponse()->getHeaders()->get('X-Cache')->getFieldValue());
+    }
+    /**
+     * MvcEvent::EVENT_ROUTE
+     * GET request
+     * Cache empty
+     */
+    public function testMvcEventEventRouteMiss()
+    {
+        $request = (new Request())->setMethod(HttpRequest::METHOD_GET);
+        $response = new Response();
+        $response->setHeaders(new Headers());
+
+        $eventManager = new \Zend\EventManager\EventManager();
+        $application = $this->getEmptyApplication();
+        $application->setRequest($request)
+            ->setResponse($response)
+            ->setEventManager($eventManager);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setResponse($response);
+        $event->setApplication($application);
+        $event->setName(MvcEvent::EVENT_ROUTE);
+
+        (new RequestCacheHandler())->setStorage($this->getEmptyCache())->attach($eventManager);
+
+        $eventManager->triggerEvent($event);
+
+        $this->assertFalse($event->getResponse()->getHeaders()->has('X-Cache'));
+    }
+
+    /**
+     * MvcEvent::EVENT_FINISH
+     * GET request
+     * Cache empty
+     * HTTP status code 200
+     */
+    public function testMvcEventEventFinishMiss()
+    {
+        $request = (new Request())->setMethod(HttpRequest::METHOD_GET);
+        $response = new Response();
+        $response->setHeaders(new Headers());
+
+        $eventManager = new \Zend\EventManager\EventManager();
+        $application = $this->getEmptyApplication();
+        $application->setRequest($request)
+            ->setResponse($response)
+            ->setEventManager($eventManager);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setResponse($response);
+        $event->setApplication($application);
+        $event->setName(MvcEvent::EVENT_FINISH);
+
+        (new RequestCacheHandler())->setStorage($this->getEmptyCache())->attach($eventManager);
+
+        $eventManager->triggerEvent($event);
+
+        $this->assertTrue($event->getResponse()->getHeaders()->has('X-Cache'));
+        $this->assertEquals('MISS', $event->getResponse()->getHeaders()->get('X-Cache')->getFieldValue());
+    }
+
+    /**
+     * MvcEvent::EVENT_FINISH
+     * GET request
+     * Cache full
+     * HTTP status code 200
+     */
+    public function testMvcEventEventFinishInCache()
+    {
+        $request = (new Request())->setMethod(HttpRequest::METHOD_GET);
+        $response = new Response();
+        $response->setHeaders(new Headers());
+
+        $eventManager = new \Zend\EventManager\EventManager();
+        $application = $this->getEmptyApplication();
+        $application->setRequest($request)
+            ->setResponse($response)
+            ->setEventManager($eventManager);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setResponse($response);
+        $event->setApplication($application);
+        $event->setName(MvcEvent::EVENT_FINISH);
+
+        (new RequestCacheHandler())->setStorage($this->getPopulatedCache())->attach($eventManager);
+
+        $eventManager->triggerEvent($event);
+
+        $this->assertFalse($event->getResponse()->getHeaders()->has('X-Cache'));
+    }
+
+    /**
+     * MvcEvent::EVENT_FINISH
+     * GET request
+     * Cache empty
+     * HTTP status code 500
+     */
+    public function testMvcEventEventFinishErrorInRequest()
+    {
+        $request = (new Request())->setMethod(HttpRequest::METHOD_GET);
+        $response = new Response();
+        $response->setStatusCode(500);
+        $response->setHeaders(new Headers());
+
+        $eventManager = new \Zend\EventManager\EventManager();
+        $application = $this->getEmptyApplication();
+        $application->setRequest($request)
+            ->setResponse($response)
+            ->setEventManager($eventManager);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setResponse($response);
+        $event->setApplication($application);
+        $event->setName(MvcEvent::EVENT_FINISH);
+
+        (new RequestCacheHandler())->setStorage($this->getEmptyCache())->attach($eventManager);
+
+        $eventManager->triggerEvent($event);
+
+        $this->assertFalse($event->getResponse()->getHeaders()->has('X-Cache'));
+    }
+
+    private function getPopulatedCache()
+    {
+        return new class extends BlackHole
+        {
+            public function hasItem($key)
+            {
+                return true;
+            }
+
+            public function getItem($key, & $success = null, & $casToken = null)
+            {
+                return serialize(new \Rend\View\Model\EmptyModel());
+            }
+        };
+    }
+
+    private function getEmptyCache()
+    {
+        return new class extends BlackHole
+        {
+            public function hasItem($key)
+            {
+                return false;
+            }
+
+            public function getItem($key, & $success = null, & $casToken = null)
+            {
+                return null;
+            }
+        };
+    }
+
+    private function getEmptyApplication()
+    {
+        return new class implements ApplicationInterface
+        {
+            private $request;
+            private $response;
+            private $eventManager;
+
+            public function getServiceManager()
+            {
+                // TODO: Implement getServiceManager() method.
+            }
+
+            public function setRequest($request)
+            {
+                $this->request = $request;
+                return $this;
+            }
+
+            public function getRequest()
+            {
+                return $this->request;
+            }
+
+            public function setResponse($response)
+            {
+                $this->response = $response;
+                return $this;
+            }
+
+            public function getResponse()
+            {
+                return $this->response;
+            }
+
+            public function run()
+            {
+                // TODO: Implement run() method.
+            }
+
+            public function setEventManager($manager)
+            {
+                $this->eventManager = $manager;
+                return $this;
+            }
+
+            public function getEventManager()
+            {
+                return $this->eventManager;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What?
Notify a client who his requesting data from this service if the response is coming from the datastore or cache.

## How?
A really simple one: in the `Module`'s event-manager, if URL is found in the cache, add `X-Cache: HIT` to the response HTTP header.

Else `X-Cache: MISS` 

## Why?
Mostly for logging... When the GraphQL server requests data from this API and logs the interaction, knowing if the data comes from cache or not, can explain the time a request took.
