### PR TITLE
Adds RabbitMQ to event-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,34 +28,6 @@ COPY ./auto/php/php.ini /usr/local/etc/php/
 
 EXPOSE 80
 
-ENV APPLICATION_ENVIRONMENT production
-
-ENV DB_HOST localhost
-ENV DB_PORT 3306
-ENV DB_NAME althingi
-ENV DB_USER root
-#ENV DB_PASSWORD
-
-ENV SEARCH none
-#   | elasticsearch | none
-
-ENV ES_HOST localhost
-ENV ES_PROTO http
-ENV ES_PORT 9200
-ENV ES_USER elastic
-ENV ES_PASSWORD changeme
-
-ENV LOG_PATH php://stdout
-ENV LOG_FORMAT line
-#    | logstash | json | line | color | none
-
-ENV CACHE_TYPE none
-#    | file (path ./data/cache) | memory | none
-ENV CACHE_HOST localhost
-ENV CACHE_PORT 6379
-
-ENV QUEUE RabbitMQ
-
 # with x-debug version
 #RUN pecl install -o -f redis \
 #    && pecl install xdebug-2.6.0 \
@@ -63,8 +35,13 @@ ENV QUEUE RabbitMQ
 #    && docker-php-ext-enable redis xdebug
 
 # - - -  Option 1
-COPY . /var/www
 WORKDIR /var/www
+
+COPY ./composer.json .
+COPY ./composer.lock .
+COPY ./phpcs.xml .
+COPY ./phpunit.xml.dist .
+
 RUN /usr/local/bin/composer install --prefer-source --no-interaction --no-dev \
     && /usr/local/bin/composer dump-autoload -o
 # - - -  end of Option 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update \
  && apt-get install -y git zlib1g-dev vim \
  && docker-php-ext-install zip \
  && docker-php-ext-install pdo_mysql \
+ && docker-php-ext-install bcmath \
+ && docker-php-ext-install sockets \
  && a2enmod rewrite \
  && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/apache2.conf \
  && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf \
@@ -51,6 +53,8 @@ ENV CACHE_TYPE none
 #    | file (path ./data/cache) | memory | none
 ENV CACHE_HOST localhost
 ENV CACHE_PORT 6379
+
+ENV QUEUE RabbitMQ
 
 # with x-debug version
 #RUN pecl install -o -f redis \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -20,22 +20,16 @@ RUN pecl install -o -f redis \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable redis xdebug
 
-ADD . /usr/src
 COPY ./auto/php/php.ini /usr/local/etc/php/
 
-ENV APPLICATION_ENVIRONMENT development
-ENV DB_HOST localhost
-ENV DB_PORT 3306
-ENV DB_NAME althingi
-ENV DB_USER root
-ENV SEARCH none
-ENV LOG_PATH none
-ENV CACHE_TYPE none
-ENV CACHE_HOST localhost
-ENV CACHE_PORT 6379
-#ENV QUEUE RabbitMQ
-
 WORKDIR /usr/src
+
+COPY ./composer.json .
+COPY ./composer.lock .
+COPY ./phpcs.xml .
+COPY ./phpunit.xml.dist .
+
+RUN mkdir -p /usr/src/data/cache
 
 RUN /usr/local/bin/composer install --no-interaction  \
     && /usr/local/bin/composer dump-autoload -o

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,6 +10,8 @@ RUN apt-get update \
  && apt-get install -y git zip unzip zlib1g-dev mysql-client \
  && docker-php-ext-install zip \
  && docker-php-ext-install pdo_mysql \
+ && docker-php-ext-install bcmath \
+ && docker-php-ext-install sockets \
  && curl -sS https://getcomposer.org/installer \
   | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -31,6 +33,7 @@ ENV LOG_PATH none
 ENV CACHE_TYPE none
 ENV CACHE_HOST localhost
 ENV CACHE_PORT 6379
+#ENV QUEUE RabbitMQ
 
 WORKDIR /usr/src
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This application is configured via environment variables:
 | DB_NAME_TEST        | althingi_test                    | <string>                              |
 | DB_SETUP            | false                            | true / false                          |
 | SEARCH              | elasticsearch                    | elasticsearch / none                  |
-| LOG_PATH            |                                  | <string>                              | Save logs to disk
+| LOG_PATH            |                                  | <string>                              | Save logs to disk or php://stdout
 | LOG_FORMAT          | none                             | logstash / json / line / color / none |
 | CACHE_TYPE          | none                             | file / memory / none                  |
 | CACHE_HOST          |                                  | <string>                              |
@@ -38,6 +38,12 @@ This application is configured via environment variables:
 | ES_PORT             | 9200                             | <number>                              |
 | ES_USER             | elastic                          | <string>                              |
 | ES_PASSWORD         | changeme                         | <string>                              |
+| QUEUE               | none                             | rabbitmq / none                       |
+| QUEUE_HOST          | localhost                        | <string>                              |
+| QUEUE_PORT          | 5672                             | <string>                              |
+| QUEUE_USER          | guest                            | <string>                              |
+| QUEUE_PASSWORD      | guest                            | <string>                              |
+| QUEUE_VHOST         | /                                | <string>                              |
 
 
 ## Database

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This application is configured via environment variables:
 | QUEUE_USER          | guest                            | <string>                              |
 | QUEUE_PASSWORD      | guest                            | <string>                              |
 | QUEUE_VHOST         | /                                | <string>                              |
+| QUEUE_FORCED        | false                            | true / false                          | if event should be sent to queue even though no update occurred
 
 
 ## Database

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "zeptech/annotations": "^1.1",
         "yohang/finite": "^1.1",
         "monolog/monolog": "^1.23",
-        "bramus/monolog-colored-line-formatter": "^2.0"
+        "bramus/monolog-colored-line-formatter": "^2.0",
+        "php-amqplib/php-amqplib": "^2.8"
     },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a44d6c6c2cfda0b6647457426ab67df",
+    "content-hash": "561bb54445365200922d15702067eda9",
     "packages": [
         {
             "name": "bramus/ansi-php",
@@ -465,6 +465,79 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "php-amqplib/php-amqplib",
+            "version": "v2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-amqplib/php-amqplib.git",
+                "reference": "84449ffd3f5a7466bbee3946facb3746ff11f075"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/84449ffd3f5a7466bbee3946facb3746ff11f075",
+                "reference": "84449ffd3f5a7466bbee3946facb3746ff11f075",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-sockets": "*",
+                "php": ">=5.4.0"
+            },
+            "replace": {
+                "videlalvaro/php-amqplib": "self.version"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "^2.9",
+                "phpunit/phpunit": "^4.8",
+                "scrutinizer/ocular": "^1.1",
+                "squizlabs/php_codesniffer": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpAmqpLib\\": "PhpAmqpLib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alvaro Videla",
+                    "role": "Original Maintainer"
+                },
+                {
+                    "name": "John Kelly",
+                    "email": "johnmkelly86@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Raúl Araya",
+                    "email": "nubeiro@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Luke Bakken",
+                    "email": "luke@bakken.io",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Formerly videlalvaro/php-amqplib.  This library is a pure PHP implementation of the AMQP protocol. It's been tested against RabbitMQ.",
+            "homepage": "https://github.com/php-amqplib/php-amqplib/",
+            "keywords": [
+                "message",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2018-11-13T09:35:17+00:00"
         },
         {
             "name": "psr/cache",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,14 @@ services:
       - DB_SETUP=false
       - CACHE_TYPE=none
       - SEARCH=none
+      - LOG_PATH=none
+      - QUEUE=none
+      - QUEUE_FORCED=false
+    volumes:
+      - ./auto/:/usr/src/auto
+      - ./config/:/usr/src/config
+      - ./module/:/usr/src/module
+      - ./public/:/usr/src/public
     command: bash -c "/usr/src/auto/run-test.sh"
 
   database:

--- a/module/Althingi/config/module.config.php
+++ b/module/Althingi/config/module.config.php
@@ -1,62 +1,67 @@
 <?php
 namespace Althingi;
 
-use Althingi\Controller\IndexController;
-use Althingi\Controller\AssemblyController;
-use Althingi\Controller\CongressmanController;
-use Althingi\Controller\SessionController;
-use Althingi\Controller\CongressmanSessionController;
-use Althingi\Controller\PartyController;
-use Althingi\Controller\ConstituencyController;
-use Althingi\Controller\PlenaryController;
-use Althingi\Controller\PlenaryAgendaController;
-use Althingi\Controller\IssueController;
-use Althingi\Controller\UndocumentedIssueController;
-use Althingi\Controller\SpeechController;
-use Althingi\Controller\VoteController;
-use Althingi\Controller\VoteItemController;
-use Althingi\Controller\CongressmanIssueController;
-use Althingi\Controller\CongressmanDocumentController;
-use Althingi\Controller\DocumentController;
-use Althingi\Controller\CommitteeController;
-use Althingi\Controller\CabinetController;
-use Althingi\Controller\PresidentController;
-use Althingi\Controller\PresidentAssemblyController;
-use Althingi\Controller\SuperCategoryController;
-use Althingi\Controller\CategoryController;
-use Althingi\Controller\IssueCategoryController;
-use Althingi\Controller\CommitteeMeetingController;
-use Althingi\Controller\CommitteeMeetingAgendaController;
-use Althingi\Controller\AssemblyCommitteeController;
-use Althingi\Controller\HighlightController;
+use Althingi\Controller\{
+    IndexController,
+    AssemblyController,
+    CongressmanController,
+    SessionController,
+    CongressmanSessionController,
+    PartyController,
+    ConstituencyController,
+    PlenaryController,
+    PlenaryAgendaController,
+    IssueController,
+    UndocumentedIssueController,
+    SpeechController,
+    VoteController,
+    VoteItemController,
+    CongressmanIssueController,
+    CongressmanDocumentController,
+    DocumentController,
+    CommitteeController,
+    CabinetController,
+    PresidentController,
+    PresidentAssemblyController,
+    SuperCategoryController,
+    CategoryController,
+    IssueCategoryController,
+    CommitteeMeetingController,
+    CommitteeMeetingAgendaController,
+    AssemblyCommitteeController,
+    HighlightController,
+    Console\SearchIndexerController as ConsoleSearchIndexerController,
+    Console\DocumentApiController as ConsoleDocumentApiController,
+    Console\IssueStatusController as ConsoleIssueStatusController,
+    Aggregate
+};
 
-use Althingi\Controller\Console\SearchIndexerController as ConsoleSearchIndexerController;
-use Althingi\Controller\Console\DocumentApiController as ConsoleDocumentApiController;
-use Althingi\Controller\Console\IssueStatusController as ConsoleIssueStatusController;
-use Althingi\Service\Assembly;
-use Althingi\Service\Cabinet;
-use Althingi\Service\Category;
-use Althingi\Service\Committee;
-use Althingi\Service\CommitteeMeeting;
-use Althingi\Service\CommitteeMeetingAgenda;
-use Althingi\Service\Congressman;
-use Althingi\Service\CongressmanDocument;
-use Althingi\Service\Constituency;
-use Althingi\Service\Document;
-use Althingi\Service\Election;
-use Althingi\Service\Issue;
-use Althingi\Service\IssueCategory;
-use Althingi\Service\Party;
-use Althingi\Service\Plenary;
-use Althingi\Service\PlenaryAgenda;
-use Althingi\Service\President;
-use Althingi\Service\SearchIssue;
-use Althingi\Service\SearchSpeech;
-use Althingi\Service\Session;
-use Althingi\Service\Speech;
-use Althingi\Service\SuperCategory;
-use Althingi\Service\Vote;
-use Althingi\Service\VoteItem;
+use Althingi\Service\{
+    Assembly,
+    Cabinet,
+    Category,
+    Committee,
+    CommitteeMeeting,
+    CommitteeMeetingAgenda,
+    Congressman,
+    CongressmanDocument,
+    Constituency,
+    Document,
+    Election,
+    Issue,
+    IssueCategory,
+    Party,
+    Plenary,
+    PlenaryAgenda,
+    President,
+    SearchIssue,
+    SearchSpeech,
+    Session,
+    Speech,
+    SuperCategory,
+    Vote,
+    VoteItem
+};
 
 use Zend\Router\Http\Literal;
 use Zend\Router\Http\Segment;
@@ -557,7 +562,116 @@ return [
                         ],
                     ]
                 ]
-            ]
+            ],
+            'samantekt' => [
+                'type' => Literal::class,
+                'options' => [
+                    'route'    => '/samantekt',
+                    'defaults' => [
+                        'controller' => IndexController::class,
+                    ],
+                ],
+                'may_terminate' => true,
+                'child_routes' => [
+                    'thingmal' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route'    => '/loggjafarthing/:assembly_id/thingmal[/:issue_id]',
+                            'constraints' => [
+                                'issue_id' => '[0-9]+',
+                            ],
+                            'defaults' => [
+                                'controller' => Aggregate\DocumentController::class, //todo
+                                'identifier' => 'document_id'
+                            ],
+                        ],
+                        'may_terminate' => true,
+                        'child_routes' => [
+                            'ferill' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/ferill',
+                                    'defaults' => [
+                                        'controller' => Aggregate\IssueController::class,
+                                        'action' => 'progress'
+                                    ],
+                                ],
+                            ],
+                            'thingskjalahopar' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/thingskjalahopar',
+                                    'defaults' => [
+                                        'controller' => Aggregate\DocumentController::class,
+                                        'action' => 'document-types'
+                                    ],
+                                ],
+                            ],
+                            'thingskjol' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/thingskjol[/:document_id]',
+                                    'constraints' => [
+                                        'document_id' => '[0-9]+',
+                                    ],
+                                    'defaults' => [
+                                        'controller' => Aggregate\DocumentController::class,
+                                        'identifier' => 'document_id'
+                                    ],
+                                ],
+                                'may_terminate' => true,
+                                'child_routes' => [
+                                    'thingmenn' => [
+                                        'type' => Segment::class,
+                                        'options' => [
+                                            'route'    => '/thingmenn',
+                                            'defaults' => [
+                                                'controller' => Aggregate\DocumentController::class,
+                                                'action' => 'proponents'
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+
+
+                    'thingmenn' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route'    => '/thingmenn/:congressman_id',
+                            'defaults' => [
+                                'controller' => Aggregate\CongressmanController::class,
+                                'action' => 'get'
+                            ],
+                        ],
+                        'may_terminate' => true,
+                        'child_routes' => [
+                            'thingmenn-flokkar' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/thingflokkar',
+                                    'defaults' => [
+                                        'controller' => Aggregate\CongressmanController::class,
+                                        'action' => 'party'
+                                    ],
+                                ],
+                            ],
+                            'thingmenn-kjordaemi' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/kjordaemi',
+                                    'defaults' => [
+                                        'controller' => Aggregate\CongressmanController::class,
+                                        'action' => 'constituency'
+                                    ],
+                                ],
+                            ],
+                        ]
+                    ],
+                ]
+            ],
         ]
     ],
 
@@ -749,6 +863,21 @@ return [
                 return (new ConsoleIssueStatusController())
                     ->setIssueService($container->get(Issue::class));
             },
+            Aggregate\CongressmanController::class => function (ServiceManager $container) {
+                return (new Aggregate\CongressmanController())
+                    ->setPartyService($container->get(Party::class))
+                    ->setCongressmanService($container->get(Congressman::class))
+                    ->setConstituencyService($container->get(Constituency::class));
+            },
+            Aggregate\DocumentController::class => function (ServiceManager $container) {
+                return (new Aggregate\DocumentController())
+                    ->setDocumentService($container->get(Document::class))
+                    ->setCongressmanDocumentService($container->get(CongressmanDocument::class));
+            },
+            Aggregate\IssueController::class => function (ServiceManager $container) {
+                return (new Aggregate\IssueController())
+                    ->setIssueService($container->get(Issue::class));
+            }
         ],
     ],
 

--- a/module/Althingi/config/module.config.php
+++ b/module/Althingi/config/module.config.php
@@ -573,6 +573,26 @@ return [
                 ],
                 'may_terminate' => true,
                 'child_routes' => [
+                    'thingmal-flokkar-stada' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route'    => '/loggjafarthing/:assembly_id/thingmal/flokkar-stada',
+                            'defaults' => [
+                                'controller' => Aggregate\IssueController::class,
+                                'action' => 'count-type-status'
+                            ],
+                        ],
+                    ],
+                    'thingmal-government' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route'    => '/loggjafarthing/:assembly_id/thingmal/stjornarfrumvorp',
+                            'defaults' => [
+                                'controller' => Aggregate\IssueController::class,
+                                'action' => 'count-government'
+                            ],
+                        ],
+                    ],
                     'thingmal' => [
                         'type' => Segment::class,
                         'options' => [
@@ -587,6 +607,26 @@ return [
                         ],
                         'may_terminate' => true,
                         'child_routes' => [
+                            'malaflokkar' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/malaflokkar',
+                                    'defaults' => [
+                                        'controller' => Aggregate\IssueCategoryController::class,
+                                        'action' => 'fetch-categories'
+                                    ],
+                                ],
+                            ],
+                            'yfir-malaflokkar' => [
+                                'type' => Segment::class,
+                                'options' => [
+                                    'route'    => '/yfir-malaflokkar',
+                                    'defaults' => [
+                                        'controller' => Aggregate\IssueCategoryController::class,
+                                        'action' => 'fetch-super-categories'
+                                    ],
+                                ],
+                            ],
                             'ferill' => [
                                 'type' => Segment::class,
                                 'options' => [
@@ -877,6 +917,11 @@ return [
             Aggregate\IssueController::class => function (ServiceManager $container) {
                 return (new Aggregate\IssueController())
                     ->setIssueService($container->get(Issue::class));
+            },
+            Aggregate\IssueCategoryController::class => function (ServiceManager $container) {
+                return (new Aggregate\IssueCategoryController())
+                    ->setCategoryService($container->get(Category::class))
+                    ->setSuperCategoryService($container->get(SuperCategory::class));
             }
         ],
     ],

--- a/module/Althingi/config/service.config.php
+++ b/module/Althingi/config/service.config.php
@@ -67,7 +67,8 @@ return [
         },
         Category::class => function (ServiceManager $sm) {
             return (new Category())
-                ->setDriver($sm->get(PDO::class));
+                ->setDriver($sm->get(PDO::class))
+                ;
         },
         CongressmanDocument::class => function (ServiceManager $sm) {
             return (new CongressmanDocument())
@@ -91,7 +92,8 @@ return [
         },
         IssueCategory::class => function (ServiceManager $sm) {
             return (new IssueCategory())
-                ->setDriver($sm->get(PDO::class));
+                ->setDriver($sm->get(PDO::class))
+                ->setEventManager($sm->get(EventsListener::class));
         },
         Party::class => function (ServiceManager $sm) {
             return (new Party())

--- a/module/Althingi/src/Controller/Aggregate/CongressmanController.php
+++ b/module/Althingi/src/Controller/Aggregate/CongressmanController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Althingi\Controller\Aggregate;
+
+use Althingi\Lib\ServiceCongressmanAwareInterface;
+use Althingi\Lib\ServiceConstituencyAwareInterface;
+use Althingi\Lib\ServicePartyAwareInterface;
+use Althingi\Service\Congressman;
+use Althingi\Service\Constituency;
+use Althingi\Service\Party;
+use Althingi\Utils\CategoryParam;
+use Rend\Controller\AbstractRestfulController;
+use Rend\View\Model\ItemModel;
+use Rend\View\Model\CollectionModel;
+use Rend\Helper\Http\Range;
+use DateTime;
+
+class CongressmanController extends AbstractRestfulController implements
+    ServiceCongressmanAwareInterface,
+    ServicePartyAwareInterface,
+    ServiceConstituencyAwareInterface
+{
+    use Range;
+
+    use CategoryParam;
+
+
+    /** @var $issueService \Althingi\Service\Congressman */
+    private $congressmanService;
+
+    /** @var $issueService \Althingi\Service\Party */
+    private $partyService;
+
+    /** @var $issueService \Althingi\Service\Constituency */
+    private $constituencyService;
+
+    public function getAction()
+    {
+        $id = $this->params('congressman_id', null);
+        return (new ItemModel($this->congressmanService->get($id)));
+    }
+
+    /**
+     * Get all party by congressman,
+     * If `date` is provided, only party on that date is returned.
+     *
+     * @return \Rend\View\Model\ModelInterface|array
+     * @output \Althingi\Model\Party | \Althingi\Model\Party[]
+     * @query date string | null
+     */
+    public function partyAction()
+    {
+        $id = $this->params('congressman_id', null);
+        $date = $this->params()->fromQuery('dags', null);
+        if ($date) {
+            return (new ItemModel($this->partyService->getByCongressman($id, new DateTime($date))));
+        } else {
+            return (new CollectionModel($this->partyService->fetchByCongressman($id)));
+        }
+    }
+
+    /**
+     * Get all constituencies by congressman,
+     * If `date` is provided, only constituency on that date is returned.
+     *
+     * @return \Rend\View\Model\ModelInterface|array
+     * @output \Althingi\Model\ConstituencyDate | \Althingi\Model\ConstituencyDate[]
+     * @query date string | null
+     */
+    public function constituencyAction()
+    {
+        $id = $this->params('congressman_id', null);
+        $date = $this->params()->fromQuery('dags', null);
+
+        if ($date) {
+            return (new ItemModel($this->constituencyService->getByCongressman($id, new DateTime($date))));
+        } else {
+            return (new CollectionModel($this->constituencyService->fetchByCongressman($id)));
+        }
+    }
+
+    /**
+     * @param Party $party
+     * @return $this
+     */
+    public function setPartyService(Party $party)
+    {
+        $this->partyService = $party;
+        return $this;
+    }
+
+    /**
+     * @param Congressman $congressman
+     * @return $this
+     */
+    public function setCongressmanService(Congressman $congressman)
+    {
+        $this->congressmanService = $congressman;
+        return $this;
+    }
+
+    /**
+     * @param Constituency $constituency
+     * @return $this
+     */
+    public function setConstituencyService(Constituency $constituency)
+    {
+        $this->constituencyService = $constituency;
+        return $this;
+    }
+}

--- a/module/Althingi/src/Controller/Aggregate/DocumentController.php
+++ b/module/Althingi/src/Controller/Aggregate/DocumentController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Althingi\Controller\Aggregate;
+
+use Althingi\Lib\ServiceCongressmanAwareInterface;
+use Althingi\Lib\ServiceConstituencyAwareInterface;
+use Althingi\Lib\ServiceDocumentAwareInterface;
+use Althingi\Lib\ServicePartyAwareInterface;
+use Althingi\Lib\ServiceProponentAwareInterface;
+use Althingi\Service\Congressman;
+use Althingi\Service\CongressmanDocument;
+use Althingi\Service\Constituency;
+use Althingi\Service\Document;
+use Althingi\Service\Party;
+use Althingi\Utils\CategoryParam;
+use Rend\Controller\AbstractRestfulController;
+use Rend\View\Model\ItemModel;
+use Rend\View\Model\CollectionModel;
+use Rend\Helper\Http\Range;
+use DateTime;
+
+class DocumentController extends AbstractRestfulController implements
+    ServiceDocumentAwareInterface,
+    ServiceProponentAwareInterface
+{
+    use Range;
+
+    use CategoryParam;
+
+    /** @var $issueService \Althingi\Service\Document */
+    private $documentService;
+
+    /** @var $issueService \Althingi\Service\CongressmanDocument */
+    private $congressmanDocumentService;
+
+    public function get($id)
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+        $documentId = $this->params('document_id', null);
+
+        return (new ItemModel($this->documentService->get($assemblyId, $issueId, $documentId)));
+    }
+
+    public function getList()
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+
+        return (new CollectionModel($this->documentService->fetchByIssue($assemblyId, $issueId)));
+    }
+
+    public function proponentsAction()
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+        $documentId = $this->params('document_id', null);
+
+        return (new ItemModel($this->congressmanDocumentService->countProponents(
+            $assemblyId,
+            $issueId,
+            $documentId
+        )));
+    }
+
+    public function documentTypesAction()
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+        return (new CollectionModel($this->documentService->countTypeByIssue($assemblyId, $issueId)));
+    }
+
+    /**
+     * @param Document $document
+     * @return $this
+     */
+    public function setDocumentService(Document $document)
+    {
+        $this->documentService = $document;
+        return $this;
+    }
+
+    /**
+     * @param CongressmanDocument $congressmanDocument
+     * @return $this
+     */
+    public function setCongressmanDocumentService(CongressmanDocument $congressmanDocument)
+    {
+        $this->congressmanDocumentService = $congressmanDocument;
+        return $this;
+    }
+}

--- a/module/Althingi/src/Controller/Aggregate/IssueCategoryController.php
+++ b/module/Althingi/src/Controller/Aggregate/IssueCategoryController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Althingi\Controller\Aggregate;
+
+use Althingi\Lib\ServiceCategoryAwareInterface;
+use Althingi\Lib\ServiceSuperCategoryAwareInterface;
+use Althingi\Service\Category;
+use Althingi\Service\SuperCategory;
+use Althingi\Utils\CategoryParam;
+use Rend\Controller\AbstractRestfulController;
+use Rend\Helper\Http\Range;
+use Rend\View\Model\CollectionModel;
+
+class IssueCategoryController extends AbstractRestfulController implements
+    ServiceCategoryAwareInterface,
+    ServiceSuperCategoryAwareInterface
+{
+    use Range;
+    use CategoryParam;
+
+    /** @var $issueService \Althingi\Service\Category */
+    private $categoryService;
+
+    /** @var $issueService \Althingi\Service\SuperCategory */
+    private $superCategoryService;
+
+    public function fetchCategoriesAction()
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+
+        return (new CollectionModel($this->categoryService->fetchByAssemblyAndIssue($assemblyId, $issueId)));
+    }
+
+    public function fetchSuperCategoriesAction()
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+
+        return (new CollectionModel($this->superCategoryService->fetchByIssue($assemblyId, $issueId)));
+    }
+
+    /**
+     * @param \Althingi\Service\Category $category
+     * @return $this
+     */
+    public function setCategoryService(Category $category)
+    {
+        $this->categoryService = $category;
+        return $this;
+    }
+
+    /**
+     * @param SuperCategory $superCategory
+     * @return $this
+     */
+    public function setSuperCategoryService(SuperCategory $superCategory)
+    {
+        $this->superCategoryService = $superCategory;
+        return $this;
+    }
+}

--- a/module/Althingi/src/Controller/Aggregate/IssueController.php
+++ b/module/Althingi/src/Controller/Aggregate/IssueController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Althingi\Controller\Aggregate;
+
+use Althingi\Lib\ServiceCongressmanAwareInterface;
+use Althingi\Lib\ServiceConstituencyAwareInterface;
+use Althingi\Lib\ServiceIssueAwareInterface;
+use Althingi\Lib\ServicePartyAwareInterface;
+use Althingi\Service\Congressman;
+use Althingi\Service\Constituency;
+use Althingi\Service\Issue;
+use Althingi\Service\Party;
+use Althingi\Utils\CategoryParam;
+use Rend\Controller\AbstractRestfulController;
+use Rend\View\Model\ItemModel;
+use Rend\View\Model\CollectionModel;
+use Rend\Helper\Http\Range;
+use DateTime;
+
+class IssueController extends AbstractRestfulController implements
+    ServiceIssueAwareInterface
+{
+    use Range;
+
+    use CategoryParam;
+
+
+    /** @var $issueService \Althingi\Service\Issue */
+    private $issueService;
+
+
+    public function progressAction()
+    {
+        $assemblyId = $this->params('assembly_id', null);
+        $issueId = $this->params('issue_id', null);
+
+        return (new CollectionModel($this->issueService->fetchProgress($assemblyId, $issueId)));
+    }
+
+    /**
+     * @param \Althingi\Service\Issue $issue
+     * @return $this
+     */
+    public function setIssueService(Issue $issue)
+    {
+        $this->issueService = $issue;
+        return $this;
+    }
+}

--- a/module/Althingi/src/Controller/AssemblyController.php
+++ b/module/Althingi/src/Controller/AssemblyController.php
@@ -185,7 +185,7 @@ class AssemblyController extends AbstractRestfulController implements
             ->setGovernmentBills(
                 $this->issueService->fetchGovernmentBillStatisticsByAssembly($assembly->getAssemblyId())
             )
-            ->setTypes($this->issueService->fetchStateByAssembly($assembly->getAssemblyId()))
+            ->setTypes($this->issueService->fetchCountByCategory($assembly->getAssemblyId()))
             ->setVotes(DateAndCountSequence::buildDateRange(
                 $assembly->getFrom(),
                 $assembly->getTo(),

--- a/module/Althingi/src/Filter/ItemStatusFilter.php
+++ b/module/Althingi/src/Filter/ItemStatusFilter.php
@@ -25,6 +25,10 @@ class ItemStatusFilter implements FilterInterface
      * Samþykkt sem lög frá Alþingi.
      * Vísað til ríkisstjórnar.
      *
+     * @todo "Ekki útrætt á 148. þingi. (Beið fyrri umræðu.)"
+     * @todo "Ekki útrætt á 148. þingi. (Var í nefnd eftir fyrri umræðu.)"
+     * @todo these are no caught in the regex.
+     *
      * @param  mixed $value
      * @throws Exception\RuntimeException If filtering $value is impossible
      * @return mixed

--- a/module/Althingi/src/Hydrator/AssemblyStatus.php
+++ b/module/Althingi/src/Hydrator/AssemblyStatus.php
@@ -21,7 +21,8 @@ class AssemblyStatus implements HydratorInterface
             ->setCount($data['count'])
             ->setType($data['type'])
             ->setTypeName($data['type_name'])
-            ->setTypeSubname($data['type_subname']);
+            ->setTypeSubname($data['type_subname'])
+            ->setStatus(array_key_exists('status', $data) ? $data['status'] : null);
     }
 
 

--- a/module/Althingi/src/Hydrator/ConstituencyDate.php
+++ b/module/Althingi/src/Hydrator/ConstituencyDate.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Althingi\Hydrator;
+
+use DateTime;
+use Zend\Hydrator\HydratorInterface;
+
+class ConstituencyDate implements HydratorInterface
+{
+    /**
+     * Hydrate $object with the provided $data.
+     *
+     * @param  array $data
+     * @param  \Althingi\Model\ConstituencyDate $object
+     * @return \Althingi\Model\ConstituencyDate
+     */
+    public function hydrate(array $data, $object)
+    {
+        return $object
+            ->setConstituencyId($data['constituency_id'])
+            ->setName($data['name'])
+            ->setAbbrShort($data['abbr_short'])
+            ->setAbbrLong($data['abbr_long'])
+            ->setDescription($data['description'])
+            ->setDate($data['date'] ? new DateTime($data['date']) : null);
+    }
+
+
+    /**
+     * Extract values from an object
+     *
+     * @param  \Althingi\Model\ConstituencyDate $object
+     * @return array
+     */
+    public function extract($object)
+    {
+        return $object->toArray();
+    }
+}

--- a/module/Althingi/src/Hydrator/ValueAndCount.php
+++ b/module/Althingi/src/Hydrator/ValueAndCount.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Althingi\Hydrator;
+
+use Zend\Hydrator\HydratorInterface;
+use DateTime;
+
+class ValueAndCount implements HydratorInterface
+{
+
+    /**
+     * Hydrate $object with the provided $data.
+     *
+     * @param  array $data
+     * @param  \Althingi\Model\ValueAndCount $object
+     * @return \Althingi\Model\ValueAndCount
+     */
+    public function hydrate(array $data, $object)
+    {
+        return $object
+            ->setValue($data['value'])
+            ->setCount($data['count']);
+    }
+
+    /**
+     * Extract values from an object
+     *
+     * @param  \Althingi\Model\ValueAndCount $object
+     * @return array
+     */
+    public function extract($object)
+    {
+        return $object->toArray();
+    }
+}

--- a/module/Althingi/src/Lib/QueueAwareInterface.php
+++ b/module/Althingi/src/Lib/QueueAwareInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Althingi\Lib;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+interface QueueAwareInterface
+{
+    public function setQueue(AMQPStreamConnection $connection);
+
+    public function getQueue(): AMQPStreamConnection;
+}

--- a/module/Althingi/src/Model/AssemblyStatus.php
+++ b/module/Althingi/src/Model/AssemblyStatus.php
@@ -16,6 +16,9 @@ class AssemblyStatus implements ModelInterface
     /** @var  string */
     private $type_subname;
 
+    /** @var string */
+    private $status;
+
     /**
      * @return int
      */
@@ -89,6 +92,24 @@ class AssemblyStatus implements ModelInterface
     }
 
     /**
+     * @return string
+     */
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status
+     * @return AssemblyStatus
+     */
+    public function setStatus(?string $status): AssemblyStatus
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -98,6 +119,7 @@ class AssemblyStatus implements ModelInterface
             'type' => $this->type,
             'type_name' => $this->type_name,
             'type_subname' => $this->type_subname,
+            'status' => $this->status,
         ];
     }
 

--- a/module/Althingi/src/Model/ConstituencyDate.php
+++ b/module/Althingi/src/Model/ConstituencyDate.php
@@ -1,0 +1,38 @@
+<?php
+namespace Althingi\Model;
+
+use DateTime;
+
+class ConstituencyDate extends Constituency
+{
+    /** @var DateTime */
+    private $date;
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate(): ?DateTime
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param \DateTime $date
+     * @return ConstituencyDate
+     */
+    public function setDate(?DateTime $date): ConstituencyDate
+    {
+        $this->date = $date;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return array_merge(parent::toArray(), [
+            'date' => $this->date ? $this->date->format('Y-m-d') : null,
+        ]);
+    }
+}

--- a/module/Althingi/src/Model/IssueTypeAndStatus.php
+++ b/module/Althingi/src/Model/IssueTypeAndStatus.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Althingi\Model;
+
+class IssueTypeAndStatus implements ModelInterface
+{
+    /** @var  string */
+    private $type;
+
+    /** @var  string */
+    private $typeName;
+
+    /** @var  string */
+    private $typeSubName;
+
+    /** @var int */
+    private $count = 0;
+
+    /** @var \Althingi\Model\IssueTypeStatus[] */
+    private $status = [];
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     * @return IssueTypeAndStatus
+     */
+    public function setType(?string $type): IssueTypeAndStatus
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypeName(): ?string
+    {
+        return $this->typeName;
+    }
+
+    /**
+     * @param string $typeName
+     * @return IssueTypeAndStatus
+     */
+    public function setTypeName(?string $typeName): IssueTypeAndStatus
+    {
+        $this->typeName = $typeName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypeSubName(): ?string
+    {
+        return $this->typeSubName;
+    }
+
+    /**
+     * @param string $typeSubName
+     * @return IssueTypeAndStatus
+     */
+    public function setTypeSubName(?string $typeSubName): IssueTypeAndStatus
+    {
+        $this->typeSubName = $typeSubName;
+        return $this;
+    }
+
+    /**
+     * @return IssueTypeStatus[]
+     */
+    public function getStatus(): array
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param IssueTypeStatus[] $status
+     * @return IssueTypeAndStatus
+     */
+    public function setStatus(array $status): IssueTypeAndStatus
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function addStatus(IssueTypeStatus $status): IssueTypeAndStatus
+    {
+        $this->status[] = $status;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @param int $count
+     * @return IssueTypeAndStatus
+     */
+    public function setCount(int $count): IssueTypeAndStatus
+    {
+        $this->count = $count;
+        return $this;
+    }
+
+    public function addCount(int $count): IssueTypeAndStatus
+    {
+        $this->count += $count;
+        return $this;
+    }
+
+    public function toArray()
+    {
+        return [
+            'type' => $this->type,
+            'typeName' => $this->typeName,
+            'typeSubName' => $this->typeSubName,
+            'status' => $this->status,
+            'count' => $this->count,
+        ];
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/module/Althingi/src/Model/ValueAndCount.php
+++ b/module/Althingi/src/Model/ValueAndCount.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Althingi\Model;
+
+class ValueAndCount implements ModelInterface
+{
+    /** @var int */
+    private $count = 0;
+
+    /** @var string */
+    private $value;
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @param int $count
+     * @return ValueAndCount
+     */
+    public function setCount(int $count): ValueAndCount
+    {
+        $this->count = $count;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     * @return ValueAndCount
+     */
+    public function setValue(?string $value): ValueAndCount
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'value' => $this->value,
+            'count' => $this->count
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/module/Althingi/src/Presenters/IndexableAssemblyPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableAssemblyPresenter.php
@@ -1,0 +1,66 @@
+<?php
+namespace Althingi\Presenters;
+
+use Althingi\Model\Assembly;
+use Althingi\Model\ModelInterface;
+use Zend\Hydrator\HydratorInterface;
+
+class IndexableAssemblyPresenter implements IndexablePresenter
+{
+    const INDEX = 'althingi_model_assembly';
+    const TYPE = 'assembly';
+
+    /** @var  \Zend\Hydrator\HydratorInterface; */
+    private $hydrator;
+
+    /** @var  \Althingi\Model\Assembly */
+    private $model;
+
+    public function __construct(Assembly $model)
+    {
+        $this->setHydrator(new \Althingi\Hydrator\Assembly());
+        $this->setModel($model);
+    }
+
+    public function setHydrator(HydratorInterface $hydrator): IndexablePresenter
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator;
+    }
+
+    public function setModel(ModelInterface $model): IndexablePresenter
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+
+    public function getIdentifier(): string
+    {
+        return (string) $this->model->getAssemblyId();
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getIndex(): string
+    {
+        return self::INDEX;
+    }
+
+    public function getData(): array
+    {
+        return $this->getHydrator()->extract($this->model);
+    }
+}

--- a/module/Althingi/src/Presenters/IndexableCongressmanDocumentPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableCongressmanDocumentPresenter.php
@@ -1,0 +1,71 @@
+<?php
+namespace Althingi\Presenters;
+
+use Althingi\Model\CongressmanDocument;
+use Althingi\Model\ModelInterface;
+use Zend\Hydrator\HydratorInterface;
+
+class IndexableCongressmanDocumentPresenter implements IndexablePresenter
+{
+    const INDEX = 'althingi_model_congressman-document';
+    const TYPE = 'congressman-document';
+
+    /** @var  \Zend\Hydrator\HydratorInterface; */
+    private $hydrator;
+
+    /** @var  \Althingi\Model\CongressmanDocument */
+    private $model;
+
+    public function __construct(CongressmanDocument $model)
+    {
+        $this->setHydrator(new \Althingi\Hydrator\CongressmanDocument());
+        $this->setModel($model);
+    }
+
+    public function setHydrator(HydratorInterface $hydrator): IndexablePresenter
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator;
+    }
+
+    public function setModel(ModelInterface $model): IndexablePresenter
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+
+    public function getIdentifier(): string
+    {
+        return implode('-', [
+            $this->model->getAssemblyId(),
+            $this->model->getIssueId(),
+            $this->model->getDocumentId(),
+            $this->model->getCongressmanId()
+        ]);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getIndex(): string
+    {
+        return self::INDEX;
+    }
+
+    public function getData(): array
+    {
+        return $this->getHydrator()->extract($this->model);
+    }
+}

--- a/module/Althingi/src/Presenters/IndexableCongressmanPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableCongressmanPresenter.php
@@ -7,6 +7,9 @@ use Zend\Hydrator\HydratorInterface;
 
 class IndexableCongressmanPresenter implements IndexablePresenter
 {
+    const INDEX = 'althingi_model_congressman';
+    const TYPE = 'congressman';
+
     /** @var  \Zend\Hydrator\HydratorInterface; */
     private $hydrator;
 
@@ -48,12 +51,12 @@ class IndexableCongressmanPresenter implements IndexablePresenter
 
     public function getType(): string
     {
-        return strtolower(str_replace('\\', '_', get_class($this->model)));
+        return self::TYPE;
     }
 
     public function getIndex(): string
     {
-        return strtolower(str_replace('\\', '_', get_class($this->model)));
+        return self::INDEX;
     }
 
     public function getData(): array

--- a/module/Althingi/src/Presenters/IndexableDocumentPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableDocumentPresenter.php
@@ -46,7 +46,11 @@ class IndexableDocumentPresenter implements IndexablePresenter
 
     public function getIdentifier(): string
     {
-        return (string) "{$this->model->getAssemblyId()}-{$this->model->getIssueId()}-{$this->model->getDocumentId()}";
+        return implode('-', [
+            $this->model->getAssemblyId(),
+            $this->model->getIssueId(),
+            $this->model->getDocumentId()
+        ]);
     }
 
     public function getType(): string

--- a/module/Althingi/src/Presenters/IndexableDocumentPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableDocumentPresenter.php
@@ -1,0 +1,66 @@
+<?php
+namespace Althingi\Presenters;
+
+use Althingi\Model\Document;
+use Althingi\Model\ModelInterface;
+use Zend\Hydrator\HydratorInterface;
+
+class IndexableDocumentPresenter implements IndexablePresenter
+{
+    const INDEX = 'althingi_model_document';
+    const TYPE = 'document';
+
+    /** @var  \Zend\Hydrator\HydratorInterface; */
+    private $hydrator;
+
+    /** @var  \Althingi\Model\Document */
+    private $model;
+
+    public function __construct(Document $model)
+    {
+        $this->setHydrator(new \Althingi\Hydrator\Document());
+        $this->setModel($model);
+    }
+
+    public function setHydrator(HydratorInterface $hydrator): IndexablePresenter
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator;
+    }
+
+    public function setModel(ModelInterface $model): IndexablePresenter
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+
+    public function getIdentifier(): string
+    {
+        return (string) "{$this->model->getAssemblyId()}-{$this->model->getIssueId()}-{$this->model->getDocumentId()}";
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getIndex(): string
+    {
+        return self::INDEX;
+    }
+
+    public function getData(): array
+    {
+        return $this->getHydrator()->extract($this->model);
+    }
+}

--- a/module/Althingi/src/Presenters/IndexableIssueCategoryPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableIssueCategoryPresenter.php
@@ -1,0 +1,71 @@
+<?php
+namespace Althingi\Presenters;
+
+use Althingi\Model\ModelInterface;
+use Althingi\Model\IssueCategory;
+use Zend\Hydrator\HydratorInterface;
+
+class IndexableIssueCategoryPresenter implements IndexablePresenter
+{
+    const INDEX = 'althingi_model_issue-category';
+    const TYPE = 'issue-category';
+
+    /** @var  \Zend\Hydrator\HydratorInterface; */
+    private $hydrator;
+
+    /** @var  \Althingi\Model\IssueCategory */
+    private $model;
+
+    public function __construct(IssueCategory $model)
+    {
+        $this->setHydrator(new \Althingi\Hydrator\IssueCategory());
+        $this->setModel($model);
+    }
+
+    public function setHydrator(HydratorInterface $hydrator): IndexablePresenter
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator;
+    }
+
+    public function setModel(ModelInterface $model): IndexablePresenter
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+
+    public function getIdentifier(): string
+    {
+        return implode('-', [
+            $this->model->getAssemblyId(),
+            $this->model->getIssueId(),
+            $this->model->getCategory(),
+            $this->model->getCategoryId()
+        ]);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getIndex(): string
+    {
+        return self::INDEX;
+    }
+
+    public function getData(): array
+    {
+        return $this->getHydrator()->extract($this->model);
+    }
+}

--- a/module/Althingi/src/Presenters/IndexableIssuePresenter.php
+++ b/module/Althingi/src/Presenters/IndexableIssuePresenter.php
@@ -8,7 +8,7 @@ use Zend\Hydrator\HydratorInterface;
 class IndexableIssuePresenter implements IndexablePresenter
 {
     const INDEX = 'althingi_model_issue';
-    const TYPE = 'althingi_model_issue';
+    const TYPE = 'issue';
 
     /** @var  \Zend\Hydrator\HydratorInterface; */
     private $hydrator;

--- a/module/Althingi/src/Presenters/IndexablePartyPresenter.php
+++ b/module/Althingi/src/Presenters/IndexablePartyPresenter.php
@@ -7,6 +7,9 @@ use Zend\Hydrator\HydratorInterface;
 
 class IndexablePartyPresenter implements IndexablePresenter
 {
+    const INDEX = 'althingi_model_party';
+    const TYPE = 'issue';
+
     /** @var  \Zend\Hydrator\HydratorInterface; */
     private $hydrator;
 
@@ -48,12 +51,12 @@ class IndexablePartyPresenter implements IndexablePresenter
 
     public function getType(): string
     {
-        return strtolower(str_replace('\\', '_', get_class($this->model)));
+        return self::TYPE;
     }
 
     public function getIndex(): string
     {
-        return strtolower(str_replace('\\', '_', get_class($this->model)));
+        return self::INDEX;
     }
 
     public function getData(): array

--- a/module/Althingi/src/Presenters/IndexableSpeechPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableSpeechPresenter.php
@@ -8,7 +8,7 @@ use Zend\Hydrator\HydratorInterface;
 class IndexableSpeechPresenter implements IndexablePresenter
 {
     const INDEX = 'althingi_model_speech';
-    const TYPE = 'althingi_model_speech';
+    const TYPE = 'speech';
 
     /** @var  \Zend\Hydrator\HydratorInterface; */
     private $hydrator;

--- a/module/Althingi/src/QueueActions/Add.php
+++ b/module/Althingi/src/QueueActions/Add.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Althingi\QueueActions;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use Psr\Log\LoggerInterface;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class Add
+{
+    /** @var \Psr\Log\LoggerInterface */
+    private $logger;
+
+    /** @var \PhpAmqpLib\Connection\AMQPStreamConnection */
+    private $client;
+
+    public function __construct(AMQPStreamConnection $client, LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        $this->client = $client;
+    }
+
+    /**
+     * @param \Zend\EventManager\Event $event
+     */
+    public function __invoke(\Zend\EventManager\Event $event): void
+    {
+        /** @var  $target \Althingi\Events\UpdateEvent */
+        $target = $event->getTarget();
+
+        $presenter = $target->getPresenter();
+        $channel = $this->client->channel();
+
+        $msg = new AMQPMessage(json_encode([
+            'id' => $presenter->getIdentifier(),
+            'body' => $presenter->getData(),
+        ]));
+
+        $channel->basic_publish($msg, 'service', "{$presenter->getType()}.add");
+
+        $this->logger->info(print_r($event, true));
+    }
+}

--- a/module/Althingi/src/QueueActions/Add.php
+++ b/module/Althingi/src/QueueActions/Add.php
@@ -14,10 +14,14 @@ class Add
     /** @var \PhpAmqpLib\Connection\AMQPStreamConnection */
     private $client;
 
-    public function __construct(AMQPStreamConnection $client, LoggerInterface $logger)
+    /** @var bool */
+    private $forced;
+
+    public function __construct(AMQPStreamConnection $client, LoggerInterface $logger, bool $isForced = false)
     {
         $this->logger = $logger;
         $this->client = $client;
+        $this->forced = $isForced;
     }
 
     /**
@@ -27,17 +31,24 @@ class Add
     {
         /** @var  $target \Althingi\Events\UpdateEvent */
         $target = $event->getTarget();
+        $params = $event->getParams();
 
-        $presenter = $target->getPresenter();
-        $channel = $this->client->channel();
+        if ($params['rows'] > 0 || $this->forced === true) {
+            $presenter = $target->getPresenter();
+            $channel = $this->client->channel();
 
-        $msg = new AMQPMessage(json_encode([
-            'id' => $presenter->getIdentifier(),
-            'body' => $presenter->getData(),
-        ]));
+            $msg = new AMQPMessage(json_encode([
+                'id' => $presenter->getIdentifier(),
+                'body' => $presenter->getData(),
+            ]));
 
-        $channel->basic_publish($msg, 'service', "{$presenter->getType()}.add");
+            $channel->basic_publish($msg, 'service', "{$presenter->getType()}.add");
 
-        $this->logger->info(print_r($event, true));
+            $this->logger->info('QUEUE', [
+                'service',
+                "{$presenter->getType()}.add",
+                $presenter->getIdentifier()
+            ]);
+        }
     }
 }

--- a/module/Althingi/src/QueueActions/Delete.php
+++ b/module/Althingi/src/QueueActions/Delete.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Althingi\QueueActions;
+
+use Psr\Log\LoggerInterface;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class Delete
+{
+    /** @var \Psr\Log\LoggerInterface */
+    private $logger;
+
+    /** @var \PhpAmqpLib\Connection\AMQPStreamConnection */
+    private $client;
+
+    public function __construct(AMQPStreamConnection $client, LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        $this->client = $client;
+    }
+
+    /**
+     * @param \Zend\EventManager\Event $event
+     */
+    public function __invoke(\Zend\EventManager\Event $event)
+    {
+        $this->logger->info(print_r($event, true));
+    }
+}

--- a/module/Althingi/src/QueueActions/QueueEventsListener.php
+++ b/module/Althingi/src/QueueActions/QueueEventsListener.php
@@ -15,6 +15,9 @@ class QueueEventsListener extends EventsListener implements QueueAwareInterface
     /** @var \PhpAmqpLib\Connection\AMQPStreamConnection  */
     protected $client;
 
+    /** @var bool */
+    protected $isForced = false;
+
     /**
      * @param EventManagerInterface $events
      * @param int $priority
@@ -23,15 +26,15 @@ class QueueEventsListener extends EventsListener implements QueueAwareInterface
     {
         $this->listeners[] = $events->attach(
             AddEvent::class,
-            new Add($this->getQueue(), $this->getLogger())
+            new Add($this->getQueue(), $this->getLogger(), $this->isForced)
         );
         $this->listeners[] = $events->attach(
             UpdateEvent::class,
-            new Update($this->getQueue(), $this->getLogger())
+            new Update($this->getQueue(), $this->getLogger(), $this->isForced)
         );
         $this->listeners[] = $events->attach(
             DeleteEvent::class,
-            new Delete($this->getQueue(), $this->getLogger())
+            new Delete($this->getQueue(), $this->getLogger(), $this->isForced)
         );
     }
 
@@ -44,5 +47,23 @@ class QueueEventsListener extends EventsListener implements QueueAwareInterface
     public function getQueue(): AMQPStreamConnection
     {
         return $this->client;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isForced(): bool
+    {
+        return $this->isForced;
+    }
+
+    /**
+     * @param bool $isForced
+     * @return QueueEventsListener
+     */
+    public function setIsForced(bool $isForced): QueueEventsListener
+    {
+        $this->isForced = $isForced;
+        return $this;
     }
 }

--- a/module/Althingi/src/QueueActions/QueueEventsListener.php
+++ b/module/Althingi/src/QueueActions/QueueEventsListener.php
@@ -1,0 +1,48 @@
+<?php
+namespace Althingi\QueueActions;
+
+use Althingi\Events\EventsListener;
+
+use Althingi\Lib\QueueAwareInterface;
+use Zend\EventManager\EventManagerInterface;
+use Althingi\Events\AddEvent;
+use Althingi\Events\UpdateEvent;
+use Althingi\Events\DeleteEvent;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class QueueEventsListener extends EventsListener implements QueueAwareInterface
+{
+    /** @var \PhpAmqpLib\Connection\AMQPStreamConnection  */
+    protected $client;
+
+    /**
+     * @param EventManagerInterface $events
+     * @param int $priority
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(
+            AddEvent::class,
+            new Add($this->getQueue(), $this->getLogger())
+        );
+        $this->listeners[] = $events->attach(
+            UpdateEvent::class,
+            new Update($this->getQueue(), $this->getLogger())
+        );
+        $this->listeners[] = $events->attach(
+            DeleteEvent::class,
+            new Delete($this->getQueue(), $this->getLogger())
+        );
+    }
+
+    public function setQueue(AMQPStreamConnection $connection)
+    {
+        $this->client = $connection;
+        return $this;
+    }
+
+    public function getQueue(): AMQPStreamConnection
+    {
+        return $this->client;
+    }
+}

--- a/module/Althingi/src/QueueActions/Update.php
+++ b/module/Althingi/src/QueueActions/Update.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Althingi\QueueActions;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use Psr\Log\LoggerInterface;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class Update
+{
+    /** @var \Psr\Log\LoggerInterface */
+    private $logger;
+
+    /** @var \PhpAmqpLib\Connection\AMQPStreamConnection */
+    private $client;
+
+    public function __construct(AMQPStreamConnection $client, LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        $this->client = $client;
+    }
+
+    /**
+     * @param \Zend\EventManager\Event $event
+     */
+    public function __invoke(\Zend\EventManager\Event $event): void
+    {
+        /** @var  $target \Althingi\Events\UpdateEvent */
+        $target = $event->getTarget();
+
+        $presenter = $target->getPresenter();
+        $channel = $this->client->channel();
+
+        $msg = new AMQPMessage(json_encode([
+            'id' => $presenter->getIdentifier(),
+            'body' => $presenter->getData(),
+        ]));
+
+        $channel->basic_publish($msg, 'service', "{$presenter->getType()}.update");
+
+        $this->logger->info(print_r($event, true));
+    }
+}

--- a/module/Althingi/src/Service/Congressman.php
+++ b/module/Althingi/src/Service/Congressman.php
@@ -378,9 +378,8 @@ class Congressman implements DatabaseAwareInterface, EventsAwareInterface
     {
         $statement = $this->getDriver()->prepare($this->toSaveString('Congressman', $data));
         $statement->execute($this->toSqlValues($data));
-        $rowCount = $statement->rowCount();
 
-        switch ($rowCount) {
+        switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
                     ->trigger(AddEvent::class, new AddEvent(new IndexableCongressmanPresenter($data)));
@@ -390,7 +389,7 @@ class Congressman implements DatabaseAwareInterface, EventsAwareInterface
                     ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableCongressmanPresenter($data)));
                 break;
         }
-        return $rowCount;
+        return $statement->rowCount();
     }
 
     /**

--- a/module/Althingi/src/Service/Congressman.php
+++ b/module/Althingi/src/Service/Congressman.php
@@ -366,7 +366,11 @@ class Congressman implements DatabaseAwareInterface, EventsAwareInterface
         $statement->execute($this->toSqlValues($data));
 
         $this->getEventManager()
-            ->trigger(AddEvent::class, new AddEvent(new IndexableCongressmanPresenter($data)));
+            ->trigger(
+                AddEvent::class,
+                new AddEvent(new IndexableCongressmanPresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
         return $this->getDriver()->lastInsertId();
     }
 
@@ -382,11 +386,20 @@ class Congressman implements DatabaseAwareInterface, EventsAwareInterface
         switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
-                    ->trigger(AddEvent::class, new AddEvent(new IndexableCongressmanPresenter($data)));
+                    ->trigger(
+                        AddEvent::class,
+                        new AddEvent(new IndexableCongressmanPresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
+            case 0:
             case 2:
                 $this->getEventManager()
-                    ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableCongressmanPresenter($data)));
+                    ->trigger(
+                        UpdateEvent::class,
+                        new UpdateEvent(new IndexableCongressmanPresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
         }
         return $statement->rowCount();
@@ -406,10 +419,12 @@ class Congressman implements DatabaseAwareInterface, EventsAwareInterface
         );
         $statement->execute($this->toSqlValues($data));
 
-        if ($statement->rowCount() > 0) {
-            $this->getEventManager()
-                ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableCongressmanPresenter($data)));
-        }
+        $this->getEventManager()
+            ->trigger(
+                UpdateEvent::class,
+                new UpdateEvent(new IndexableCongressmanPresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
         return $statement->rowCount();
     }

--- a/module/Althingi/src/Service/Constituency.php
+++ b/module/Althingi/src/Service/Constituency.php
@@ -3,6 +3,8 @@
 namespace Althingi\Service;
 
 use Althingi\Lib\DatabaseAwareInterface;
+use Althingi\Model\ConstituencyDate as ConstituencyDateModel;
+use Althingi\Hydrator\ConstituencyDate as ConstituencyDateHydrator;
 use Althingi\Model\Constituency as ConstituencyModel;
 use Althingi\Hydrator\Constituency as ConstituencyHydrator;
 use PDO;
@@ -22,9 +24,9 @@ class Constituency implements DatabaseAwareInterface
 
     /**
      * @param int $id
-     * @return \Althingi\Model\Constituency
+     * @return \Althingi\Model\Constituency | null
      */
-    public function get(int $id): ?ConstituencyModel
+    public function get(int $id): ?ConstituencyDateModel
     {
         $statement = $this->getDriver()->prepare(
             'select * from `Constituency` 
@@ -35,6 +37,59 @@ class Constituency implements DatabaseAwareInterface
         return $object
             ? (new ConstituencyHydrator())->hydrate($object, new ConstituencyModel())
             : null;
+    }
+
+    /**
+     * Get Constituency by congressman on a specific date.
+     *
+     * @param int $congressmanId
+     * @param \DateTime $date
+     * @return ConstituencyDateModel | null
+     */
+    public function getByCongressman(int $congressmanId, \DateTime $date)
+    {
+        $statement = $this->getDriver()->prepare('
+            select C.*, S.`from` as `date` from
+            (
+                select * from `Session` S where
+                (:date between S.`from` and S.`to`) or
+                (:date >= S.`from` and S.`to` is null)
+            ) S
+            Join `Constituency` C on (C.constituency_id = S.constituency_id)
+            where S.congressman_id = :congressman_id;
+        ');
+        $statement->execute([
+            'congressman_id' => $congressmanId,
+            'date' => $date->format('Y-m-d'),
+        ]);
+
+        $object = $statement->fetch(PDO::FETCH_ASSOC);
+        return $object
+            ? (new ConstituencyDateHydrator())->hydrate($object, new ConstituencyDateModel())
+            : null ;
+    }
+
+    /**
+     * Get all Constituencies by congressman, order by first occupied.
+     *
+     * @param int $congressmanId
+     * @return array
+     */
+    public function fetchByCongressman(int $congressmanId)
+    {
+        $statement = $this->getDriver()->prepare('
+            select C.*, S.`from` as `date` from `Session` S
+                join `Constituency` C on (C.constituency_id = S.constituency_id)
+            where S.congressman_id = :constituency_id
+            group by C.constituency_id
+            having min(S.`from`)
+            order by S.`from`;
+        ');
+        $statement->execute(['constituency_id' => $congressmanId]);
+
+        return array_map(function ($object) {
+            return (new ConstituencyDateHydrator())->hydrate($object, new ConstituencyDateModel());
+        }, $statement->fetchAll(PDO::FETCH_ASSOC));
     }
 
     /**

--- a/module/Althingi/src/Service/Constituency.php
+++ b/module/Althingi/src/Service/Constituency.php
@@ -26,7 +26,7 @@ class Constituency implements DatabaseAwareInterface
      * @param int $id
      * @return \Althingi\Model\Constituency | null
      */
-    public function get(int $id): ?ConstituencyDateModel
+    public function get(int $id): ?ConstituencyModel
     {
         $statement = $this->getDriver()->prepare(
             'select * from `Constituency` 

--- a/module/Althingi/src/Service/Issue.php
+++ b/module/Althingi/src/Service/Issue.php
@@ -559,7 +559,11 @@ class Issue implements DatabaseAwareInterface, EventsAwareInterface
         $statement->execute($this->toSqlValues($data));
 
         $this->getEventManager()
-            ->trigger(AddEvent::class, new AddEvent(new IndexableIssuePresenter($data)));
+            ->trigger(
+                AddEvent::class,
+                new AddEvent(new IndexableIssuePresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
         return $this->getDriver()->lastInsertId();
     }
@@ -576,11 +580,20 @@ class Issue implements DatabaseAwareInterface, EventsAwareInterface
         switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
-                    ->trigger(AddEvent::class, new AddEvent(new IndexableIssuePresenter($data)));
+                    ->trigger(
+                        AddEvent::class,
+                        new AddEvent(new IndexableIssuePresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
+            case 0:
             case 2:
                 $this->getEventManager()
-                    ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableIssuePresenter($data)));
+                    ->trigger(
+                        UpdateEvent::class,
+                        new UpdateEvent(new IndexableIssuePresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
         }
         return $statement->rowCount();
@@ -602,11 +615,13 @@ class Issue implements DatabaseAwareInterface, EventsAwareInterface
             )
         );
         $statement->execute($this->toSqlValues($data));
+        $this->getEventManager()
+            ->trigger(
+                UpdateEvent::class,
+                new UpdateEvent(new IndexableIssuePresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
-        if ($statement->rowCount() > 0) {
-            $this->getEventManager()
-                ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableIssuePresenter($data)));
-        }
         return $statement->rowCount();
     }
 

--- a/module/Althingi/src/Service/Issue.php
+++ b/module/Althingi/src/Service/Issue.php
@@ -572,9 +572,8 @@ class Issue implements DatabaseAwareInterface, EventsAwareInterface
     {
         $statement = $this->getDriver()->prepare($this->toSaveString('Issue', $data));
         $statement->execute($this->toSqlValues($data));
-        $rowCount = $statement->rowCount();
 
-        switch ($rowCount) {
+        switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
                     ->trigger(AddEvent::class, new AddEvent(new IndexableIssuePresenter($data)));
@@ -584,7 +583,7 @@ class Issue implements DatabaseAwareInterface, EventsAwareInterface
                     ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableIssuePresenter($data)));
                 break;
         }
-        return $rowCount;
+        return $statement->rowCount();
     }
 
     /**

--- a/module/Althingi/src/Service/Party.php
+++ b/module/Althingi/src/Service/Party.php
@@ -234,15 +234,21 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
      */
     public function save(PartyModel $data): int
     {
-        $statement = $this->getDriver()->prepare(
-            $this->toSaveString('Party', $data)
-        );
+        $statement = $this->getDriver()->prepare($this->toSaveString('Party', $data));
         $statement->execute($this->toSqlValues($data));
+        $rowCount = $statement->rowCount();
 
-        $this->getEventManager()
-            ->trigger(AddEvent::class, new AddEvent(new IndexablePartyPresenter($data)));
-
-        return $statement->rowCount();
+        switch ($rowCount) {
+            case 1:
+                $this->getEventManager()
+                    ->trigger(AddEvent::class, new AddEvent(new IndexablePartyPresenter($data)));
+                break;
+            case 2:
+                $this->getEventManager()
+                    ->trigger(UpdateEvent::class, new UpdateEvent(new IndexablePartyPresenter($data)));
+                break;
+        }
+        return $rowCount;
     }
 
     /**
@@ -256,8 +262,10 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
         );
         $statement->execute($this->toSqlValues($data));
 
-        $this->getEventManager()
-            ->trigger(UpdateEvent::class, new UpdateEvent(new IndexablePartyPresenter($data)));
+        if ($statement->rowCount() > 0) {
+            $this->getEventManager()
+                ->trigger(UpdateEvent::class, new UpdateEvent(new IndexablePartyPresenter($data)));
+        }
 
         return $statement->rowCount();
     }

--- a/module/Althingi/src/Service/Party.php
+++ b/module/Althingi/src/Service/Party.php
@@ -223,7 +223,11 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
         $statement->execute($this->toSqlValues($data));
 
         $this->getEventManager()
-            ->trigger(AddEvent::class, new AddEvent(new IndexablePartyPresenter($data)));
+            ->trigger(
+                AddEvent::class,
+                new AddEvent(new IndexablePartyPresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
         return $this->getDriver()->lastInsertId();
     }
@@ -242,9 +246,14 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
                 $this->getEventManager()
                     ->trigger(AddEvent::class, new AddEvent(new IndexablePartyPresenter($data)));
                 break;
+            case 0:
             case 2:
                 $this->getEventManager()
-                    ->trigger(UpdateEvent::class, new UpdateEvent(new IndexablePartyPresenter($data)));
+                    ->trigger(
+                        UpdateEvent::class,
+                        new UpdateEvent(new IndexablePartyPresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
         }
         return $statement->rowCount();
@@ -261,10 +270,12 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
         );
         $statement->execute($this->toSqlValues($data));
 
-        if ($statement->rowCount() > 0) {
-            $this->getEventManager()
-                ->trigger(UpdateEvent::class, new UpdateEvent(new IndexablePartyPresenter($data)));
-        }
+        $this->getEventManager()
+            ->trigger(
+                UpdateEvent::class,
+                new UpdateEvent(new IndexablePartyPresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
         return $statement->rowCount();
     }

--- a/module/Althingi/src/Service/Party.php
+++ b/module/Althingi/src/Service/Party.php
@@ -236,9 +236,8 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
     {
         $statement = $this->getDriver()->prepare($this->toSaveString('Party', $data));
         $statement->execute($this->toSqlValues($data));
-        $rowCount = $statement->rowCount();
 
-        switch ($rowCount) {
+        switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
                     ->trigger(AddEvent::class, new AddEvent(new IndexablePartyPresenter($data)));
@@ -248,7 +247,7 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
                     ->trigger(UpdateEvent::class, new UpdateEvent(new IndexablePartyPresenter($data)));
                 break;
         }
-        return $rowCount;
+        return $statement->rowCount();
     }
 
     /**

--- a/module/Althingi/src/Service/Speech.php
+++ b/module/Althingi/src/Service/Speech.php
@@ -416,9 +416,8 @@ class Speech implements DatabaseAwareInterface, EventsAwareInterface
         $data->setWordCount(str_word_count($data->getText()));
         $statement = $this->getDriver()->prepare($this->toSaveString('Speech', $data));
         $statement->execute($this->toSqlValues($data));
-        $rowCount = $statement->rowCount();
 
-        switch ($rowCount) {
+        switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
                     ->trigger(AddEvent::class, new AddEvent(new IndexableSpeechPresenter($data)));
@@ -428,7 +427,7 @@ class Speech implements DatabaseAwareInterface, EventsAwareInterface
                     ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableSpeechPresenter($data)));
                 break;
         }
-        return $rowCount;
+        return $statement->rowCount();
     }
 
     /**

--- a/module/Althingi/src/Service/Speech.php
+++ b/module/Althingi/src/Service/Speech.php
@@ -402,7 +402,11 @@ class Speech implements DatabaseAwareInterface, EventsAwareInterface
         $statement->execute($this->toSqlValues($data));
 
         $this->getEventManager()
-            ->trigger(AddEvent::class, new AddEvent(new IndexableSpeechPresenter($data)));
+            ->trigger(
+                AddEvent::class,
+                new AddEvent(new IndexableSpeechPresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
         return $this->getDriver()->lastInsertId();
     }
@@ -420,11 +424,20 @@ class Speech implements DatabaseAwareInterface, EventsAwareInterface
         switch ($statement->rowCount()) {
             case 1:
                 $this->getEventManager()
-                    ->trigger(AddEvent::class, new AddEvent(new IndexableSpeechPresenter($data)));
+                    ->trigger(
+                        AddEvent::class,
+                        new AddEvent(new IndexableSpeechPresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
+            case 0:
             case 2:
                 $this->getEventManager()
-                    ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableSpeechPresenter($data)));
+                    ->trigger(
+                        UpdateEvent::class,
+                        new UpdateEvent(new IndexableSpeechPresenter($data)),
+                        ['rows' => $statement->rowCount()]
+                    );
                 break;
         }
         return $statement->rowCount();
@@ -444,10 +457,12 @@ class Speech implements DatabaseAwareInterface, EventsAwareInterface
         );
         $statement->execute($this->toSqlValues($data));
 
-        if ($statement->rowCount() > 0) {
-            $this->getEventManager()
-                ->trigger(UpdateEvent::class, new UpdateEvent(new IndexableSpeechPresenter($data)));
-        }
+        $this->getEventManager()
+            ->trigger(
+                UpdateEvent::class,
+                new UpdateEvent(new IndexableSpeechPresenter($data)),
+                ['rows' => $statement->rowCount()]
+            );
 
         return $statement->rowCount();
     }

--- a/module/Althingi/src/Utils/RabbitMQBlackHoleClient.php
+++ b/module/Althingi/src/Utils/RabbitMQBlackHoleClient.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Althingi\Utils;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Wire\AMQPWriter;
+
+class RabbitMQBlackHoleClient extends AMQPStreamConnection
+{
+    public function __construct()
+    {
+    }
+
+    public function reconnect()
+    {
+    }
+
+    public function __clone()
+    {
+    }
+
+    public function __destruct()
+    {
+    }
+
+    public function select($sec, $usec = 0)
+    {
+        return null;
+    }
+
+    public function set_close_on_destruct($close = true)
+    {
+    }
+
+    public function write($data)
+    {
+    }
+
+    public function get_free_channel_id()
+    {
+    }
+
+    public function send_content($channel, $class_id, $weight, $body_size, $packed_properties, $body, $pkt = null)
+    {
+    }
+
+    public function prepare_content($channel, $class_id, $weight, $body_size, $packed_properties, $body, $pkt = null)
+    {
+        return new AMQPWriter();
+    }
+
+    public function channel($channel_id = null)
+    {
+        return new AMQPChannel(null/*$this->connection*/, $channel_id);
+    }
+
+    public function close($reply_code = 0, $reply_text = '', $method_sig = array(0, 0))
+    {
+        return null;
+    }
+
+    public function getSocket()
+    {
+    }
+
+    public function getIO()
+    {
+        return $this->io;
+    }
+
+    public function set_connection_block_handler($callback)
+    {
+    }
+
+    public function set_connection_unblock_handler($callback)
+    {
+    }
+
+    public function isConnected()
+    {
+        return true;
+    }
+
+    public function connectOnConstruct()
+    {
+        return true;
+    }
+
+    public function getServerProperties()
+    {
+        return [];
+    }
+
+    public function getLibraryProperties()
+    {
+        return self::$LIBRARY_PROPERTIES;
+    }
+
+    public static function create_connection($hosts, $options = array())
+    {
+    }
+
+    public static function validate_host($host)
+    {
+    }
+}

--- a/module/Althingi/src/Utils/RabbitMQBlackHoleClient.php
+++ b/module/Althingi/src/Utils/RabbitMQBlackHoleClient.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Althingi\Utils;
 
 use PhpAmqpLib\Channel\AMQPChannel;
@@ -56,7 +55,7 @@ class RabbitMQBlackHoleClient extends AMQPStreamConnection
 
     public function channel($channel_id = null)
     {
-        return new AMQPChannel(null/*$this->connection*/, $channel_id);
+        return new RabbitMQChannelBlackHoleClient(null);
     }
 
     public function close($reply_code = 0, $reply_text = '', $method_sig = [0, 0])

--- a/module/Althingi/src/Utils/RabbitMQBlackHoleClient.php
+++ b/module/Althingi/src/Utils/RabbitMQBlackHoleClient.php
@@ -29,6 +29,7 @@ class RabbitMQBlackHoleClient extends AMQPStreamConnection
         return null;
     }
 
+    // phpcs:ignore
     public function set_close_on_destruct($close = true)
     {
     }
@@ -37,14 +38,17 @@ class RabbitMQBlackHoleClient extends AMQPStreamConnection
     {
     }
 
+    // phpcs:ignore
     public function get_free_channel_id()
     {
     }
 
+    // phpcs:ignore
     public function send_content($channel, $class_id, $weight, $body_size, $packed_properties, $body, $pkt = null)
     {
     }
 
+    // phpcs:ignore
     public function prepare_content($channel, $class_id, $weight, $body_size, $packed_properties, $body, $pkt = null)
     {
         return new AMQPWriter();
@@ -55,7 +59,7 @@ class RabbitMQBlackHoleClient extends AMQPStreamConnection
         return new AMQPChannel(null/*$this->connection*/, $channel_id);
     }
 
-    public function close($reply_code = 0, $reply_text = '', $method_sig = array(0, 0))
+    public function close($reply_code = 0, $reply_text = '', $method_sig = [0, 0])
     {
         return null;
     }
@@ -69,11 +73,11 @@ class RabbitMQBlackHoleClient extends AMQPStreamConnection
         return $this->io;
     }
 
-    public function set_connection_block_handler($callback)
+    public function set_connection_block_handler($callback) // phpcs:ignore
     {
     }
 
-    public function set_connection_unblock_handler($callback)
+    public function set_connection_unblock_handler($callback) // phpcs:ignore
     {
     }
 
@@ -97,10 +101,12 @@ class RabbitMQBlackHoleClient extends AMQPStreamConnection
         return self::$LIBRARY_PROPERTIES;
     }
 
-    public static function create_connection($hosts, $options = array())
+    // phpcs:ignore
+    public static function create_connection($hosts, $options = [])
     {
     }
 
+    // phpcs:ignore
     public static function validate_host($host)
     {
     }

--- a/module/Althingi/src/Utils/RabbitMQChannelBlackHoleClient.php
+++ b/module/Althingi/src/Utils/RabbitMQChannelBlackHoleClient.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Althingi\Utils;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+
+class RabbitMQChannelBlackHoleClient extends AMQPChannel
+{
+
+    public function __construct($connection, $channel_id = null, $auto_decode = true)
+    {
+    }
+
+    public function close($reply_code = 0, $reply_text = '', $method_sig = [0, 0])
+    {
+    }
+
+    public function flow($active)
+    {
+    }
+
+    public function access_request(  // phpcs:ignore
+        $realm,
+        $exclusive = false,
+        $passive = false,
+        $active = false,
+        $write = false,
+        $read = false
+    ) {
+    }
+
+    public function exchange_declare(  // phpcs:ignore
+        $exchange,
+        $type,
+        $passive = false,
+        $durable = false,
+        $auto_delete = true,
+        $internal = false,
+        $nowait = false,
+        $arguments = [],
+        $ticket = null
+    ) {
+    }
+
+    public function exchange_delete(  // phpcs:ignore
+        $exchange,
+        $if_unused = false,
+        $nowait = false,
+        $ticket = null
+    ) {
+    }
+
+    public function exchange_bind(  // phpcs:ignore
+        $destination,
+        $source,
+        $routing_key = '',
+        $nowait = false,
+        $arguments = [],
+        $ticket = null
+    ) {
+    }
+
+    public function exchange_unbind( // phpcs:ignore
+        $destination,
+        $source,
+        $routing_key = '',
+        $nowait = false,
+        $arguments = [],
+        $ticket = null
+    ) {
+    }
+
+    public function queue_bind(  // phpcs:ignore
+        $queue,
+        $exchange,
+        $routing_key = '',
+        $nowait = false,
+        $arguments = [],
+        $ticket = null
+    ) {
+    }
+
+    public function queue_unbind( // phpcs:ignore
+        $queue,
+        $exchange,
+        $routing_key = '',
+        $arguments = [],
+        $ticket = null
+    ) {
+    }
+
+    public function queue_declare( // phpcs:ignore
+        $queue = '',
+        $passive = false,
+        $durable = false,
+        $exclusive = false,
+        $auto_delete = true,
+        $nowait = false,
+        $arguments = [],
+        $ticket = null
+    ) {
+    }
+
+    public function queue_delete(  // phpcs:ignore
+        $queue = '',
+        $if_unused = false,
+        $if_empty = false,
+        $nowait = false,
+        $ticket = null
+    ) {
+    }
+
+    public function queue_purge($queue = '', $nowait = false, $ticket = null) // phpcs:ignore
+    {
+    }
+
+    public function basic_ack($delivery_tag, $multiple = false) // phpcs:ignore
+    {
+    }
+
+    public function basic_nack($delivery_tag, $multiple = false, $requeue = false) // phpcs:ignore
+    {
+    }
+
+    public function basic_cancel($consumer_tag, $nowait = false, $noreturn = false) // phpcs:ignore
+    {
+    }
+
+    public function basic_consume( // phpcs:ignore
+        $queue = '',
+        $consumer_tag = '',
+        $no_local = false,
+        $no_ack = false,
+        $exclusive = false,
+        $nowait = false,
+        $callback = null,
+        $ticket = null,
+        $arguments = []
+    ) {
+    }
+
+    public function basic_get($queue = '', $no_ack = false, $ticket = null) // phpcs:ignore
+    {
+    }
+
+    public function basic_publish( // phpcs:ignore
+        $msg,
+        $exchange = '',
+        $routing_key = '',
+        $mandatory = false,
+        $immediate = false,
+        $ticket = null
+    ) {
+    }
+
+    public function batch_basic_publish( // phpcs:ignore
+        $msg,
+        $exchange = '',
+        $routing_key = '',
+        $mandatory = false,
+        $immediate = false,
+        $ticket = null
+    ) {
+    }
+
+    public function publish_batch() // phpcs:ignore
+    {
+    }
+
+    public function basic_qos($prefetch_size, $prefetch_count, $a_global) // phpcs:ignore
+    {
+    }
+
+    public function basic_recover($requeue = false) // phpcs:ignore
+    {
+    }
+
+    public function basic_reject($delivery_tag, $requeue) // phpcs:ignore
+    {
+    }
+
+    public function tx_commit() // phpcs:ignore
+    {
+    }
+
+    public function tx_rollback() // phpcs:ignore
+    {
+    }
+
+    public function confirm_select($nowait = false) // phpcs:ignore
+    {
+    }
+
+    public function confirm_select_ok($reader) // phpcs:ignore
+    {
+    }
+
+    public function wait_for_pending_acks($timeout = 0) // phpcs:ignore
+    {
+    }
+
+    public function wait_for_pending_acks_returns($timeout = 0) // phpcs:ignore
+    {
+    }
+
+    public function tx_select() // phpcs:ignore
+    {
+    }
+
+    public function set_return_listener($callback) // phpcs:ignore
+    {
+    }
+
+    public function set_nack_handler($callback) // phpcs:ignore
+    {
+    }
+
+    public function set_ack_handler($callback) // phpcs:ignore
+    {
+    }
+}

--- a/module/Althingi/tests/Controller/AggregateCongressmanControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateCongressmanControllerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace AlthingiTest\Controller;
+
+use Althingi\Model\Assembly as AssemblyModel;
+use Althingi\Model\Cabinet as CabinetModel;
+use Althingi\Service\Assembly;
+use Althingi\Service\Congressman;
+use Althingi\Service\CongressmanDocument;
+use Althingi\Service\Constituency;
+use Althingi\Service\Document;
+use Althingi\Service\President;
+use Althingi\Service\Issue;
+use Althingi\Service\Party;
+use Althingi\Service\Vote;
+use Althingi\Service\Speech;
+use Althingi\Service\Cabinet;
+use Althingi\Service\Category;
+use Althingi\Service\Election;
+use AlthingiTest\ServiceHelper;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+
+/**
+ * Class AssemblyControllerTest
+ * @package Althingi\Controller
+ * @coversDefaultClass \Althingi\Controller\Aggregate\CongressmanController
+ * @covers \Althingi\Controller\Aggregate\CongressmanController::setPartyService
+ * @covers \Althingi\Controller\Aggregate\CongressmanController::setCongressmanService
+ * @covers \Althingi\Controller\Aggregate\CongressmanController::setConstituencyService
+
+ */
+class AggregateCongressmanControllerTest extends AbstractHttpControllerTestCase
+{
+    use ServiceHelper;
+
+    public function setUp()
+    {
+        $this->setApplicationConfig(
+            include __DIR__ .'/../../../../config/application.config.php'
+        );
+
+        parent::setUp();
+
+        $this->buildServices([
+            Congressman::class,
+            Party::class,
+            Constituency::class
+        ]);
+    }
+
+    public function tearDown()
+    {
+        $this->destroyServices();
+        \Mockery::close();
+        return parent::tearDown();
+    }
+
+    /**
+     * @covers ::getAction
+     */
+    public function testGetAction()
+    {
+        $this->getMockService(Congressman::class)
+            ->shouldReceive('get')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/thingmenn/1', 'GET');
+
+        $this->assertControllerClass('CongressmanController');
+        $this->assertActionName('get');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::partyAction
+     */
+    public function testPartyAction()
+    {
+        $this->getMockService(Party::class)
+            ->shouldReceive('fetchByCongressman')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/thingmenn/1/thingflokkar', 'GET');
+
+        $this->assertControllerClass('CongressmanController');
+        $this->assertActionName('party');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::partyAction
+     */
+    public function testPartyActionWithDate()
+    {
+        $this->getMockService(Party::class)
+            ->shouldReceive('getByCongressman')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/thingmenn/1/thingflokkar?dags=2001-01-01', 'GET');
+
+        $this->assertControllerClass('CongressmanController');
+        $this->assertActionName('party');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::constituencyAction
+     */
+    public function testConstituencyAction()
+    {
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('fetchByCongressman')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/thingmenn/1/kjordaemi', 'GET');
+
+        $this->assertControllerClass('CongressmanController');
+        $this->assertActionName('constituency');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::constituencyAction
+     */
+    public function testConstituencyActionWithDate()
+    {
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/thingmenn/1/kjordaemi?dags=2001-01-01', 'GET');
+
+        $this->assertControllerClass('CongressmanController');
+        $this->assertActionName('constituency');
+        $this->assertResponseStatusCode(200);
+    }
+
+}

--- a/module/Althingi/tests/Controller/AggregateCongressmanControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateCongressmanControllerTest.php
@@ -139,5 +139,4 @@ class AggregateCongressmanControllerTest extends AbstractHttpControllerTestCase
         $this->assertActionName('constituency');
         $this->assertResponseStatusCode(200);
     }
-
 }

--- a/module/Althingi/tests/Controller/AggregateDocumentControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateDocumentControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace AlthingiTest\Controller;
+
+use Althingi\Model\Assembly as AssemblyModel;
+use Althingi\Model\Cabinet as CabinetModel;
+use Althingi\Service\Assembly;
+use Althingi\Service\CongressmanDocument;
+use Althingi\Service\Document;
+use Althingi\Service\President;
+use Althingi\Service\Issue;
+use Althingi\Service\Party;
+use Althingi\Service\Vote;
+use Althingi\Service\Speech;
+use Althingi\Service\Cabinet;
+use Althingi\Service\Category;
+use Althingi\Service\Election;
+use AlthingiTest\ServiceHelper;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+
+/**
+ * Class AssemblyControllerTest
+ * @package Althingi\Controller
+ * @coversDefaultClass \Althingi\Controller\Aggregate\DocumentController
+ * @covers \Althingi\Controller\Aggregate\DocumentController::setDocumentService
+ * @covers \Althingi\Controller\Aggregate\DocumentController::setCongressmanDocumentService
+
+ */
+class AggregateDocumentControllerTest extends AbstractHttpControllerTestCase
+{
+    use ServiceHelper;
+
+    public function setUp()
+    {
+        $this->setApplicationConfig(
+            include __DIR__ .'/../../../../config/application.config.php'
+        );
+
+        parent::setUp();
+
+        $this->buildServices([
+            Document::class,
+            CongressmanDocument::class,
+        ]);
+    }
+
+    public function tearDown()
+    {
+        $this->destroyServices();
+        \Mockery::close();
+        return parent::tearDown();
+    }
+
+    /**
+     * @covers ::get
+     */
+    public function testGet()
+    {
+        $this->getMockService(Document::class)
+            ->shouldReceive('get')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/loggjafarthing/1/thingmal/2/thingskjol/3', 'GET');
+
+        $this->assertControllerClass('DocumentController');
+        $this->assertActionName('get');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::get
+     */
+    public function testGetList()
+    {
+        $this->getMockService(Document::class)
+            ->shouldReceive('fetchByIssue')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/loggjafarthing/1/thingmal/2/thingskjol', 'GET');
+
+        $this->assertControllerClass('DocumentController');
+        $this->assertActionName('getList');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::proponentsAction
+     */
+    public function testProponentsAction()
+    {
+        $this->getMockService(CongressmanDocument::class)
+            ->shouldReceive('countProponents')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/loggjafarthing/1/thingmal/2/thingskjol/3/thingmenn', 'GET');
+
+        $this->assertControllerClass('DocumentController');
+        $this->assertActionName('proponents');
+        $this->assertResponseStatusCode(200);
+    }
+}

--- a/module/Althingi/tests/Controller/AggregateIssueControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateIssueControllerTest.php
@@ -65,5 +65,4 @@ class AggregateIssueControllerTest extends AbstractHttpControllerTestCase
         $this->assertActionName('progress');
         $this->assertResponseStatusCode(200);
     }
-
 }

--- a/module/Althingi/tests/Controller/AggregateIssueControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateIssueControllerTest.php
@@ -65,4 +65,38 @@ class AggregateIssueControllerTest extends AbstractHttpControllerTestCase
         $this->assertActionName('progress');
         $this->assertResponseStatusCode(200);
     }
+
+    /**
+     * @covers ::countTypeStatusAction
+     */
+    public function testCountTypeAction()
+    {
+        $this->getMockService(Issue::class)
+            ->shouldReceive('fetchCountByCategoryAndStatus')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/loggjafarthing/1/thingmal/flokkar-stada', 'GET');
+
+        $this->assertControllerClass('IssueController');
+        $this->assertActionName('count-type-status');
+        $this->assertResponseStatusCode(200);
+    }
+
+    /**
+     * @covers ::countGovernmentAction
+     */
+    public function testCountGovernmentAction()
+    {
+        $this->getMockService(Issue::class)
+            ->shouldReceive('fetchCountByGovernment')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/loggjafarthing/1/thingmal/stjornarfrumvorp', 'GET');
+
+        $this->assertControllerClass('IssueController');
+        $this->assertActionName('count-government');
+        $this->assertResponseStatusCode(200);
+    }
 }

--- a/module/Althingi/tests/Controller/AggregateIssueControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateIssueControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AlthingiTest\Controller;
+
+use Althingi\Model\Assembly as AssemblyModel;
+use Althingi\Model\Cabinet as CabinetModel;
+use Althingi\Service\Assembly;
+use Althingi\Service\CongressmanDocument;
+use Althingi\Service\Document;
+use Althingi\Service\President;
+use Althingi\Service\Issue;
+use Althingi\Service\Party;
+use Althingi\Service\Vote;
+use Althingi\Service\Speech;
+use Althingi\Service\Cabinet;
+use Althingi\Service\Category;
+use Althingi\Service\Election;
+use AlthingiTest\ServiceHelper;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+
+/**
+ * Class AssemblyControllerTest
+ * @package Althingi\Controller
+ * @coversDefaultClass \Althingi\Controller\Aggregate\IssueController
+ * @covers \Althingi\Controller\Aggregate\IssueController::setIssueService
+
+ */
+class AggregateIssueControllerTest extends AbstractHttpControllerTestCase
+{
+    use ServiceHelper;
+
+    public function setUp()
+    {
+        $this->setApplicationConfig(
+            include __DIR__ .'/../../../../config/application.config.php'
+        );
+
+        parent::setUp();
+
+        $this->buildServices([
+            Issue::class,
+        ]);
+    }
+
+    public function tearDown()
+    {
+        $this->destroyServices();
+        \Mockery::close();
+        return parent::tearDown();
+    }
+
+    /**
+     * @covers ::progressAction
+     */
+    public function testGet()
+    {
+        $this->getMockService(Issue::class)
+            ->shouldReceive('fetchProgress')
+            ->once()
+            ->getMock();
+
+        $this->dispatch('/samantekt/loggjafarthing/1/thingmal/2/ferill', 'GET');
+
+        $this->assertControllerClass('IssueController');
+        $this->assertActionName('progress');
+        $this->assertResponseStatusCode(200);
+    }
+
+}

--- a/module/Althingi/tests/Service/CongressmanTest.php
+++ b/module/Althingi/tests/Service/CongressmanTest.php
@@ -148,12 +148,12 @@ class CongressmanTest extends TestCase
 
         $expectedData = [
             (new CongressmanValueModel())
-                ->setCongressmanId(1)
-                ->setName('name1')
-                ->setBirth(new \DateTime('2000-01-01')),
-            (new CongressmanValueModel())
                 ->setCongressmanId(2)
                 ->setName('name2')
+                ->setBirth(new \DateTime('2000-01-01')),
+            (new CongressmanValueModel())
+                ->setCongressmanId(1)
+                ->setName('name1')
                 ->setBirth(new \DateTime('2000-01-01')),
         ];
 

--- a/module/Althingi/tests/Service/CongressmanTest.php
+++ b/module/Althingi/tests/Service/CongressmanTest.php
@@ -148,12 +148,12 @@ class CongressmanTest extends TestCase
 
         $expectedData = [
             (new CongressmanValueModel())
-                ->setCongressmanId(2)
-                ->setName('name2')
-                ->setBirth(new \DateTime('2000-01-01')),
-            (new CongressmanValueModel())
                 ->setCongressmanId(1)
                 ->setName('name1')
+                ->setBirth(new \DateTime('2000-01-01')),
+            (new CongressmanValueModel())
+                ->setCongressmanId(2)
+                ->setName('name2')
                 ->setBirth(new \DateTime('2000-01-01')),
         ];
 

--- a/module/Althingi/tests/Service/IssueTest.php
+++ b/module/Althingi/tests/Service/IssueTest.php
@@ -3,8 +3,10 @@
 namespace AlthingiTest\Service;
 
 use Althingi\Model\IssueTypeStatus;
+use Althingi\QueueActions\QueueEventsListener;
 use Althingi\Service\Issue;
 use Althingi\ElasticSearchActions\ElasticSearchEventsListener;
+use Althingi\Utils\RabbitMQBlackHoleClient;
 use AlthingiTest\DatabaseConnection;
 use PHPUnit\Framework\TestCase;
 use Althingi\Model\Issue as IssueModel;
@@ -180,9 +182,10 @@ class IssueTest extends TestCase
 
     public function testCreate()
     {
-        $serviceEventListener = (new ElasticSearchEventsListener())
-                ->setElasticSearchClient(new ElasticBlackHoleClient())
-                ->setLogger(new NullLogger());
+        $serviceEventListener = (new QueueEventsListener())
+                ->setQueue(new RabbitMQBlackHoleClient())
+                ->setLogger(new NullLogger())
+                ->setIsForced(true);
         $eventManager = new EventManager();
         $serviceEventListener->attach($eventManager);
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,10 @@
 
     <exclude-pattern>*.phtml</exclude-pattern>
 
+    <rule ref="PSR2.Namespaces.UseDeclaration">
+        <exclude-pattern>*.config.php</exclude-pattern>
+    </rule>
+
     <!-- display progress -->
     <arg value="p"/>
     <arg name="colors"/>


### PR DESCRIPTION
## What?
Adds events that send topic to RabbitMQ.

## How?
Attached to the EventManager in `/service.config.php`, a new listener is added, that listener attaches events that send messages to RabbitMQ.

Also in `/service.config.php` a `AMQPStreamConnection ` key is created that returns a RabbitMQ configured client.

All derived classes from `IndexablePresenter ` will return an `index: string` (more for ElasticSearch) and a `type: string` (more for RabbitMQ).

`RabbitMQBlackHoleClient.php` is added for testing.

Services classes' (Congressman, Issue, Party and Speech) `update()` method will now, based off of `affectedRows`, either fire an event or not. No need to fire off an event if nothing changed.


Services classes' (Congressman, Issue, Party and Speech) `save()` method will now, based off of `affectedRows`, either fire an `update` or `add` event.

## Why?
To be able to send messages to a Queue Exchange.

First step in decoupling logging/aggregation/search from this API.