### PR TITLE
Adds Constituency along with Congressman

### DIFF
--- a/module/Althingi/config/module.config.php
+++ b/module/Althingi/config/module.config.php
@@ -771,6 +771,7 @@ return [
                     ->setVoteService($container->get(Service\Vote::class))
                     ->setSpeechService($container->get(Service\Speech::class))
                     ->setPartyService($container->get(Service\Party::class))
+                    ->setConstituencyService($container->get(Service\Constituency::class))
                     ->setIssueService($container->get(Service\Issue::class))
                     ->setAssemblyService($container->get(Service\Assembly::class))
                     ->setCongressmanService($container->get(Service\Congressman::class))
@@ -816,6 +817,7 @@ return [
                     ->setVoteService($container->get(Service\Vote::class))
                     ->setDocumentService($container->get(Service\Document::class))
                     ->setSearchIssueService($container->get(Service\SearchIssue::class))
+                    ->setConstituencyService($container->get(Service\Constituency::class))
                     ->setIssueStore($container->get(Store\Issue::class));
             },
             Controller\SpeechController::class => function (ServiceManager $container) {
@@ -824,6 +826,7 @@ return [
                     ->setCongressmanService($container->get(Service\Congressman::class))
                     ->setPartyService($container->get(Service\Party::class))
                     ->setPlenaryService($container->get(Service\Plenary::class))
+                    ->setConstituencyService($container->get(Service\Constituency::class))
                     ->setSearchSpeechService($container->get(Service\SearchSpeech::class));
             },
             Controller\VoteController::class => function (ServiceManager $container) {
@@ -835,6 +838,7 @@ return [
                     ->setVoteService($container->get(Service\Vote::class))
                     ->setPartyService($container->get(Service\Party::class))
                     ->setCongressmanService($container->get(Service\Congressman::class))
+                    ->setConstituencyService($container->get(Service\Constituency::class))
                     ->setVoteItemService($container->get(Service\VoteItem::class));
             },
             Controller\CongressmanIssueController::class => function (ServiceManager $container) {
@@ -851,6 +855,7 @@ return [
                     ->setCongressmanService($container->get(Service\Congressman::class))
                     ->setPartyService($container->get(Service\Party::class))
                     ->setVoteService($container->get(Service\Vote::class))
+                    ->setConstituencyService($container->get(Service\Constituency::class))
                     ->setDocumentService($container->get(Service\Document::class));
             },
             Controller\CommitteeController::class => function (ServiceManager $container) {

--- a/module/Althingi/src/Controller/DocumentController.php
+++ b/module/Althingi/src/Controller/DocumentController.php
@@ -2,6 +2,7 @@
 
 namespace Althingi\Controller;
 
+use Althingi\Injector\ServiceConstituencyAwareInterface;
 use Althingi\Model;
 use Althingi\Service;
 use Althingi\Form;
@@ -10,6 +11,7 @@ use Althingi\Injector\ServiceCongressmanAwareInterface;
 use Althingi\Injector\ServiceDocumentAwareInterface;
 use Althingi\Injector\ServicePartyAwareInterface;
 use Althingi\Injector\ServiceVoteAwareInterface;
+use Althingi\Service\Constituency;
 use Rend\Controller\AbstractRestfulController;
 use Rend\View\Model\CollectionModel;
 use Rend\View\Model\EmptyModel;
@@ -21,7 +23,8 @@ class DocumentController extends AbstractRestfulController implements
     ServiceVoteAwareInterface,
     ServiceCongressmanAwareInterface,
     ServicePartyAwareInterface,
-    ServiceVoteItemAwareInterface
+    ServiceVoteItemAwareInterface,
+    ServiceConstituencyAwareInterface
 {
     /** @var  \Althingi\Service\Document */
     private $documentService;
@@ -37,6 +40,9 @@ class DocumentController extends AbstractRestfulController implements
 
     /** @var  \Althingi\Service\Party */
     private $partyService;
+
+    /** @var  \Althingi\Service\Constituency */
+    private $constituencyService;
 
     /**
      * @param mixed $id
@@ -71,6 +77,9 @@ class DocumentController extends AbstractRestfulController implements
                 return (new Model\ProponentPartyProperties())
                     ->setCongressman($proponent)
                     ->setParty($this->partyService->getByCongressman(
+                        $proponent->getCongressmanId(),
+                        $document->getDate()
+                    ))->setConstituency($this->constituencyService->getByCongressman(
                         $proponent->getCongressmanId(),
                         $document->getDate()
                     ));
@@ -198,6 +207,16 @@ class DocumentController extends AbstractRestfulController implements
     public function setVoteItemService(Service\VoteItem $voteItem)
     {
         $this->voteItemService = $voteItem;
+        return $this;
+    }
+
+    /**
+     * @param Constituency $constituency
+     * @return $this
+     */
+    public function setConstituencyService(Constituency $constituency)
+    {
+        $this->constituencyService = $constituency;
         return $this;
     }
 }

--- a/module/Althingi/src/Model/CongressmanPartiesProperties.php
+++ b/module/Althingi/src/Model/CongressmanPartiesProperties.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Althingi\Model;
+
+class CongressmanPartiesProperties implements ModelInterface
+{
+    /** @var  \Althingi\Model\Congressman */
+    private $congressman;
+
+    /** @var  \Althingi\Model\Party[] */
+    private $parties = [];
+
+    /** @var \Althingi\Model\Constituency */
+    private $constituency = null;
+
+    /** @var  \Althingi\Model\Assembly */
+    private $assembly;
+
+    /**
+     * @return \Althingi\Model\Congressman
+     */
+    public function getCongressman(): Congressman
+    {
+        return $this->congressman;
+    }
+
+    /**
+     * @param Congressman $congressman
+     * @return CongressmanPartiesProperties
+     */
+    public function setCongressman(Congressman $congressman): CongressmanPartiesProperties
+    {
+        $this->congressman = $congressman;
+        return $this;
+    }
+
+
+    /**
+     * @return Assembly
+     */
+    public function getAssembly(): Assembly
+    {
+        return $this->assembly;
+    }
+
+    /**
+     * @param Assembly $assembly
+     * @return CongressmanPartiesProperties
+     */
+    public function setAssembly(Assembly $assembly): CongressmanPartiesProperties
+    {
+        $this->assembly = $assembly;
+        return $this;
+    }
+
+    /**
+     * @return Constituency
+     */
+    public function getConstituency(): ?Constituency
+    {
+        return $this->constituency;
+    }
+
+    /**
+     * @param Constituency $constituency
+     * @return CongressmanPartiesProperties
+     */
+    public function setConstituency(?Constituency $constituency): CongressmanPartiesProperties
+    {
+        $this->constituency = $constituency;
+        return $this;
+    }
+
+    /**
+     * @return Party[]
+     */
+    public function getParties(): array
+    {
+        return $this->parties;
+    }
+
+    /**
+     * @param Party[] $parties
+     * @return CongressmanPartiesProperties
+     */
+    public function setParties(array $parties): CongressmanPartiesProperties
+    {
+        $this->parties = $parties;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_merge($this->congressman->toArray(), [
+            'parties' => $this->parties,
+            'assembly' => $this->assembly,
+            'constituency' => $this->constituency
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/module/Althingi/src/Service/Constituency.php
+++ b/module/Althingi/src/Service/Constituency.php
@@ -67,6 +67,32 @@ class Constituency implements DatabaseAwareInterface
     }
 
     /**
+     * Get Constituency by congressman on a specific assembly.
+     *
+     * @param int $congressmanId
+     * @param int $assemblyId
+     * @return \Althingi\Model\ConstituencyDate | null
+     */
+    public function getByAssemblyAndCongressman(int $congressmanId, int $assemblyId): ? Model\ConstituencyDate
+    {
+        $statement = $this->getDriver()->prepare('
+            select C.*, S.`from` as `date` from Session S
+                join Constituency C on (S.constituency_id = C.constituency_id)
+            where S.assembly_id = :assembly_id and S.congressman_id = :congressman_id order by S.`from` limit 0, 1
+            ;
+        ');
+        $statement->execute([
+            'congressman_id' => $congressmanId,
+            'assembly_id' => $assemblyId,
+        ]);
+
+        $object = $statement->fetch(PDO::FETCH_ASSOC);
+        return $object
+            ? (new Hydrator\ConstituencyDate())->hydrate($object, new Model\ConstituencyDate())
+            : null ;
+    }
+
+    /**
      * Get all Constituencies by congressman, order by first occupied.
      *
      * @param int $congressmanId

--- a/module/Althingi/src/Service/Party.php
+++ b/module/Althingi/src/Service/Party.php
@@ -114,6 +114,30 @@ class Party implements DatabaseAwareInterface, EventsAwareInterface
     }
 
     /**
+     * @param int $congressmanId
+     * @param int $assemblyId
+     * @return \Althingi\Model\Party[]
+     */
+    public function fetchByCongressmanAndAssembly(int $congressmanId, int $assemblyId): array
+    {
+
+        $statement = $this->getDriver()->prepare('
+            select P.* from Session S
+                join Party P on (S.party_id = P.party_id)
+                where congressman_id = :congressman_id and assembly_id = :assembly_id
+                group by S.party_id
+                order by S.`from`;
+        ');
+        $statement->execute([
+            'congressman_id' => $congressmanId,
+            'assembly_id' => $assemblyId,
+        ]);
+        return array_map(function ($object) {
+            return (new Hydrator\Party())->hydrate($object, new Model\Party());
+        }, $statement->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    /**
      * @param $assemblyId
      * @param array $exclude
      * @return \Althingi\Model\Party[]

--- a/module/Althingi/tests/Controller/CongressmanControllerTest.php
+++ b/module/Althingi/tests/Controller/CongressmanControllerTest.php
@@ -9,6 +9,7 @@ use Althingi\Model\Issue as IssueModel;
 use Althingi\Model\IssueCategoryAndTime as IssueCategoryAndTimeModel;
 use Althingi\Service\Assembly;
 use Althingi\Service\Congressman;
+use Althingi\Service\Constituency;
 use Althingi\Service\Issue;
 use Althingi\Service\IssueCategory;
 use Althingi\Service\Party;
@@ -64,6 +65,7 @@ class CongressmanControllerTest extends AbstractHttpControllerTestCase
             Speech::class,
             IssueCategory::class,
             Assembly::class,
+            Constituency::class
         ]);
     }
 
@@ -362,20 +364,28 @@ class CongressmanControllerTest extends AbstractHttpControllerTestCase
             ->andReturn((new \Althingi\Model\Assembly())->setAssemblyId(1))
             ->getMock();
 
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByAssemblyAndCongressman')
+            ->with(1, 1)
+            ->once()
+            ->andReturn((new \Althingi\Model\ConstituencyDate()))
+            ->getMock();
+
         $this->getMockService(Congressman::class)
             ->shouldReceive('fetchByAssembly')
             ->with(1, null)
             ->once()
             ->andReturn([
-                (new CongressmanAndParty())->setPartyId(100)
+                (new CongressmanAndParty())
+                    ->setCongressmanId(1)
+                    ->setPartyId(100)
             ])
             ->getMock();
 
         $this->getMockService(Party::class)
-            ->shouldReceive('get')
-            ->with(100)
-            ->andReturn(new PartyModel())
-            ->once()
+            ->shouldReceive('fetchByCongressmanAndAssembly')
+            ->with(1, 1)
+            ->andReturn([])
             ->getMock();
 
         $this->dispatch('/loggjafarthing/1/thingmenn');

--- a/module/Althingi/tests/Controller/DocumentControllerTest.php
+++ b/module/Althingi/tests/Controller/DocumentControllerTest.php
@@ -3,6 +3,7 @@
 namespace AlthingiTest\Controller;
 
 use Althingi\Service\Congressman;
+use Althingi\Service\Constituency;
 use Althingi\Service\Document;
 use Althingi\Service\Party;
 use Althingi\Service\Vote;
@@ -42,7 +43,7 @@ class DocumentControllerTest extends AbstractHttpControllerTestCase
             VoteItem::class,
             Congressman::class,
             Party::class,
-
+            Constituency::class
         ]);
     }
 
@@ -124,6 +125,11 @@ class DocumentControllerTest extends AbstractHttpControllerTestCase
         $this->getMockService(Party::class)
             ->shouldReceive('getByCongressman')
             ->andReturn(new PartyModel())
+            ->getMock();
+
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new \Althingi\Model\ConstituencyDate())
             ->getMock();
 
         $this->dispatch('/loggjafarthing/145/thingmal/a/2/thingskjal', 'GET');

--- a/module/Althingi/tests/Controller/IssueControllerTest.php
+++ b/module/Althingi/tests/Controller/IssueControllerTest.php
@@ -2,9 +2,11 @@
 
 namespace AlthingiTest\Controller;
 
+use Althingi\Model\ConstituencyDate;
 use Althingi\Model\Proponent;
 use Althingi\Service\Assembly;
 use Althingi\Service\Congressman;
+use Althingi\Service\Constituency;
 use Althingi\Service\Document;
 use Althingi\Service\Issue;
 use Althingi\Service\Party;
@@ -52,6 +54,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             Vote::class,
             Assembly::class,
             Speech::class,
+            Constituency::class,
         ]);
     }
 
@@ -113,6 +116,12 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             ->with(100, 200, 'A')
             ->getMock();
 
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->twice()
+            ->getMock();
+
 
         $this->dispatch('/loggjafarthing/100/thingmal/a/200', 'GET');
 
@@ -171,6 +180,12 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             ->andReturn([])
             ->once()
             ->with(100, 200, 'B')
+            ->getMock();
+
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->once()
             ->getMock();
 
 
@@ -305,6 +320,12 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             ->times(25)
             ->getMock()
         ;
+
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->times(25)
+            ->getMock();
 
         $this->dispatch('/loggjafarthing/100/thingmal', 'GET');
 

--- a/module/Althingi/tests/Controller/SpeechControllerTest.php
+++ b/module/Althingi/tests/Controller/SpeechControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace AlthingiTest\Controller;
 
+use Althingi\Model\ConstituencyDate;
 use Althingi\Model\SpeechAndPosition;
 use Althingi\Service\Congressman;
+use Althingi\Service\Constituency;
 use Althingi\Service\Party;
 use Althingi\Service\Speech;
 use AlthingiTest\ServiceHelper;
@@ -34,6 +36,7 @@ class SpeechControllerTest extends AbstractHttpControllerTestCase
             Speech::class,
             Congressman::class,
             Party::class,
+            Constituency::class
         ]);
     }
 
@@ -72,6 +75,12 @@ class SpeechControllerTest extends AbstractHttpControllerTestCase
             ->andReturn(new \Althingi\Model\Party())
             ->getMock();
 
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->once()
+            ->getMock();
+
         $this->dispatch('/loggjafarthing/1/thingmal/a/3/raedur/4', 'GET');
 
         $this->assertControllerName(\Althingi\Controller\SpeechController::class);
@@ -106,6 +115,12 @@ class SpeechControllerTest extends AbstractHttpControllerTestCase
         $this->getMockService(Party::class)
             ->shouldReceive('getByCongressman')
             ->andReturn(new \Althingi\Model\Party())
+            ->getMock();
+
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->times(25)
             ->getMock();
 
         $this->dispatch('/loggjafarthing/1/thingmal/a/3/raedur/4', 'GET');
@@ -215,6 +230,12 @@ class SpeechControllerTest extends AbstractHttpControllerTestCase
             ->andReturn(new \Althingi\Model\Party())
             ->once();
 
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->once()
+            ->getMock();
+
         $this->dispatch('/loggjafarthing/144/thingmal/b/3/raedur');
 
         $this->assertControllerName(\Althingi\Controller\SpeechController::class);
@@ -254,6 +275,12 @@ class SpeechControllerTest extends AbstractHttpControllerTestCase
             ->shouldReceive('getByCongressman')
             ->andReturn(new \Althingi\Model\Party())
             ->once();
+
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->once()
+            ->getMock();
 
         $this->dispatch('/loggjafarthing/144/thingmal/a/3/raedur');
 
@@ -300,6 +327,12 @@ class SpeechControllerTest extends AbstractHttpControllerTestCase
             ->shouldReceive('getByCongressman')
             ->andReturn(new \Althingi\Model\Party())
             ->times(20);
+
+        $this->getMockService(Constituency::class)
+            ->shouldReceive('getByCongressman')
+            ->andReturn(new ConstituencyDate())
+            ->times(20)
+            ->getMock();
 
         $this->dispatch('/loggjafarthing/144/thingmal/a/3/raedur');
 

--- a/module/Althingi/tests/Controller/VoteItemControllerTest.php
+++ b/module/Althingi/tests/Controller/VoteItemControllerTest.php
@@ -3,6 +3,7 @@
 namespace AlthingiTest\Controller;
 
 use Althingi\Model\VoteItemAndAssemblyIssue;
+use Althingi\Service\Constituency;
 use Althingi\Service\VoteItem;
 use AlthingiTest\ServiceHelper;
 use Mockery;
@@ -28,6 +29,7 @@ class VoteItemControllerTest extends AbstractHttpControllerTestCase
 
         $this->buildServices([
             VoteItem::class,
+            Constituency::class
         ]);
     }
 


### PR DESCRIPTION
## What?
It would be super great to get the **constituency** along with **party** of a congressman in some situations. This PR provides that.

## How?
The `CongressmanPartyProperties` model already had **constituency** as a property, so it's just a matter of populating that when it makes sense.

this is usually how it goes:

```php
$congressmanPartyProperties
    ->setConstituency($this->constituencyService->getByCongressman(
        $congressman->getCongressmanId(),
        $congressman->getBegin()
    ));
```

Another thing needed to be done is to inject `constituencyService` into all Controllers

## Why?
S we can see the **constituency** of a Congressman.