### PR TITLE
Adds indexing to Session

### DIFF
--- a/auto/index-assembly.sh
+++ b/auto/index-assembly.sh
@@ -2,4 +2,4 @@
 
 SCRIPT=$( cd "$( dirname "$0" )" && pwd )/../public/index.php
 
-php ${SCRIPT} index:speech
+php ${SCRIPT} index:assembly --assembly=$1

--- a/auto/index-session.sh
+++ b/auto/index-session.sh
@@ -2,4 +2,4 @@
 
 SCRIPT=$( cd "$( dirname "$0" )" && pwd )/../public/index.php
 
-php ${SCRIPT} index:issue --assembly=$1 --issue=$2 --category=$3
+php ${SCRIPT} index:session --assembly=$1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,63 @@ version: '3'
 
 services:
 
+  ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+
+  ## Start the API without any dependant services.
+
+  ##  This is great for using the dependant services
+  ##  in the production environment, but running
+  ##  the API Service code locally.
+
+  ##  Set ENV_DB_HOST, ENV_ES_HOST, ENV_STORAGE_HOST
+  ##  to loggjafarthing.einarvalur.co
+  ##  and ENV_SEARCH to elasticsearch
+
+  ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+  run:
+    container_name: server_run
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8080:80
+    volumes:
+      - ./auto/:/var/www/auto
+      - ./config/:/var/www/config
+      - ./module/:/var/www/module
+      - ./public/:/var/www/public
+    environment:
+      - LOG_PATH=php://stdout
+      - LOG_FORMAT=line
+
+      - APPLICATION_ENVIRONMENT=development
+
+      - DB_HOST=${ENV_DB_HOST:-host.docker.internal}
+      - DB_PORT=${ENV_DB_PORT:-4406}
+      - DB_NAME=${ENV_DB_NAME:-althingi}
+      - DB_USER=${ENV_DB_USER:-root}
+      - DB_PASSWORD=${ENV_DB_PASSWORD:-example}
+
+      - CACHE_TYPE=none
+
+      - SEARCH=${ENV_SEARCH:-none}
+
+      - ES_HOST=${ENV_ES_HOST:-host.docker.internal}
+      - ES_PROTO=${ENV_ES_PROTO:-http}
+      - ES_PORT=${ENV_ES_PORT:-9200}
+      - ES_USER=${ENV_ES_USER:-elastic}
+      - ES_PASSWORD=${ENV_ES_PASSWORD:-changeme}
+
+      - QUEUE=none
+
+      - STORAGE_HOST=${ENV_STORAGE_HOST:-host.docker.internal}
+      - STORAGE_DB=${ENV_STORAGE_DB:-althingi}
+      - STORAGE_PORT=${ENV_STORAGE_PORT:-27017}
+      - STORAGE_USER=${ENV_STORAGE_USER:-wo}
+      - STORAGE_PASSWORD=${STORAGE_PASSWORD:-long@pass!123}
+
+
+
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
   # TEST
   #

--- a/module/Althingi/config/module.config.php
+++ b/module/Althingi/config/module.config.php
@@ -816,6 +816,7 @@ return [
                     ->setSpeechStore($container->get(Store\Speech::class))
                     ->setPartyStore($container->get(Store\Party::class))
                     ->setCategoryStore($container->get(Store\Category::class))
+                    ->setCongressmanStore($container->get(Store\Congressman::class))
                     ;
             },
             Controller\CongressmanController::class => function (ServiceManager $container) {
@@ -998,6 +999,7 @@ return [
                     ->setVoteService($container->get(Service\Vote::class))
                     ->setAssemblyService($container->get(Service\Assembly::class))
                     ->setVoteItemService($container->get(Service\VoteItem::class))
+                    ->setSessionService($container->get(Service\Session::class))
                     ->setLogger($container->get(LoggerInterface::class))
                     ->setQueue($container->get(AMQPStreamConnection::class))
                     ;
@@ -1085,6 +1087,15 @@ return [
                         'defaults' => [
                             'controller' => Console\IndexerIssueController::class,
                             'action' => 'assembly'
+                        ],
+                    ],
+                ],
+                'session' => [
+                    'options' => [
+                        'route' => 'index:session [--assembly=|-a]',
+                        'defaults' => [
+                            'controller' => Console\IndexerIssueController::class,
+                            'action' => 'session'
                         ],
                     ],
                 ],

--- a/module/Althingi/src/Controller/AssemblyController.php
+++ b/module/Althingi/src/Controller/AssemblyController.php
@@ -4,6 +4,7 @@ namespace Althingi\Controller;
 
 use Althingi\Injector\ServiceCongressmanAwareInterface;
 use Althingi\Injector\StoreCategoryAwareInterface;
+use Althingi\Injector\StoreCongressmanAwareInterface;
 use Althingi\Injector\StoreIssueAwareInterface;
 use Althingi\Injector\StorePartyAwareInterface;
 use Althingi\Injector\StoreSpeechAwareInterface;
@@ -50,7 +51,8 @@ class AssemblyController extends AbstractRestfulController implements
     StoreVoteAwareInterface,
     StoreSpeechAwareInterface,
     StorePartyAwareInterface,
-    StoreCategoryAwareInterface
+    StoreCategoryAwareInterface,
+    StoreCongressmanAwareInterface
 {
     use Range;
 
@@ -98,6 +100,9 @@ class AssemblyController extends AbstractRestfulController implements
 
     /** @var $categoryStore \Althingi\Store\Category */
     private $categoryStore;
+
+    /** @var $categoryStore \Althingi\Store\Congressman */
+    private $congressmanStore;
 
     /**
      * Get one Assembly.
@@ -456,7 +461,6 @@ class AssemblyController extends AbstractRestfulController implements
      *
      * @param Model\Assembly $assembly
      * @return Model\AssemblyStatusProperties
-     * @todo the average-age is still being calculated from the DB.
      * @todo the Election results are not being fetched at all.
      */
     private function fetchStatisticsFromStore(Model\Assembly $assembly)
@@ -464,7 +468,7 @@ class AssemblyController extends AbstractRestfulController implements
         return (new Model\AssemblyStatusProperties())
             ->setVotes($this->voteStore->fetchFrequencyByAssembly($assembly->getAssemblyId()))
             ->setSpeeches($this->speechStore->fetchFrequencyByAssembly($assembly->getAssemblyId()))
-            ->setAverageAge($this->congressmanService->getAverageAgeByAssembly(
+            ->setAverageAge($this->congressmanStore->getAverageAgeByAssembly(
                 $assembly->getAssemblyId(),
                 $assembly->getFrom()
             ))
@@ -473,5 +477,15 @@ class AssemblyController extends AbstractRestfulController implements
             ->setElection(null)
             ->setElectionResults([])
         ;
+    }
+
+    /**
+     * @param \Althingi\Store\Congressman $congressman
+     * @return $this
+     */
+    public function setCongressmanStore(Store\Congressman $congressman)
+    {
+        $this->congressmanStore = $congressman;
+        return $this;
     }
 }

--- a/module/Althingi/src/Presenters/IndexableSessionPresenter.php
+++ b/module/Althingi/src/Presenters/IndexableSessionPresenter.php
@@ -1,0 +1,67 @@
+<?php
+namespace Althingi\Presenters;
+
+use Althingi\Model\ModelInterface;
+use Althingi\Model\Session;
+use Althingi\Model\Speech;
+use Zend\Hydrator\HydratorInterface;
+
+class IndexableSessionPresenter implements IndexablePresenter
+{
+    const INDEX = 'althingi_model_session';
+    const TYPE = 'session';
+
+    /** @var  \Zend\Hydrator\HydratorInterface; */
+    private $hydrator;
+
+    /** @var  \Althingi\Model\Session */
+    private $model;
+
+    public function __construct(Session $model)
+    {
+        $this->setHydrator(new \Althingi\Hydrator\Session());
+        $this->setModel($model);
+    }
+
+    public function setHydrator(HydratorInterface $hydrator): IndexablePresenter
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator;
+    }
+
+    public function setModel(ModelInterface $model): IndexablePresenter
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->model->getSessionId();
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getIndex(): string
+    {
+        return self::INDEX;
+    }
+
+    public function getData(): array
+    {
+        return $this->getHydrator()->extract($this->model);
+    }
+}


### PR DESCRIPTION
## What?
Adds queue events in the Session Service.
Adds console actions to index all sessions per assembly.

## How?
Updates `create` and `update` methods in `Service\Session` so an even is fired. This will index the session (MongoDB)

Adds `IndexableSessionPresenter`.

Also creates a Console controller action that can fetch all sessions per Assembly and trigger **create** event.


## Why?
So sessions end up in MongoDB.