### PR TITLE
Adds paths for party and constituency for the accumulator

### DIFF
--- a/module/Althingi/config/module.config.php
+++ b/module/Althingi/config/module.config.php
@@ -572,6 +572,26 @@ return [
                 ],
                 'may_terminate' => true,
                 'child_routes' => [
+                    'thingflokkar' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route'    => '/thingflokkar[/:party_id]',
+                            'defaults' => [
+                                'controller' => Aggregate\PartyController::class,
+                                'identifier' => 'party_id'
+                            ],
+                        ],
+                    ],
+                    'kjordaemi' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route'    => '/kjordaemi[/:constituency_id]',
+                            'defaults' => [
+                                'controller' => Aggregate\ConstituencyController::class,
+                                'identifier' => 'constituency_id'
+                            ],
+                        ],
+                    ],
                     'atkvaedi' => [
                         'type' => Segment::class,
                         'options' => [
@@ -1033,6 +1053,14 @@ return [
             Aggregate\VoteController::class => function (ServiceManager $container) {
                 return (new Aggregate\VoteController())
                     ->setVoteService($container->get(Service\Vote::class));
+            },
+            Aggregate\PartyController::class => function (ServiceManager $container) {
+                return (new Aggregate\PartyController())
+                    ->setPartyService($container->get(Service\Party::class));
+            },
+            Aggregate\ConstituencyController::class => function (ServiceManager $container) {
+                return (new Aggregate\ConstituencyController())
+                    ->setConstituencyService($container->get(Service\Constituency::class));
             },
             Controller\InflationController::class => function (ServiceManager $container) {
                 return (new Controller\InflationController())

--- a/module/Althingi/src/Controller/Aggregate/ConstituencyController.php
+++ b/module/Althingi/src/Controller/Aggregate/ConstituencyController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Althingi\Controller\Aggregate;
+
+use Althingi\Injector\ServiceConstituencyAwareInterface;
+use Althingi\Service\Constituency;
+use Rend\Controller\AbstractRestfulController;
+use Rend\View\Model\ItemModel;
+use Rend\Helper\Http\Range;
+
+class ConstituencyController extends AbstractRestfulController implements
+    ServiceConstituencyAwareInterface
+{
+    use Range;
+
+    /** @var $issueService \Althingi\Service\Constituency */
+    private $constituencyService;
+
+    /**
+     * @return ItemModel|\Rend\View\Model\ModelInterface
+     * @output \Althingi\Model\Constituency
+     */
+    public function get()
+    {
+        return (new ItemModel(
+            $this->constituencyService->get($this->params('constituency_id', null))
+        ));
+    }
+
+    /**
+     * @param Constituency $constituency
+     * @return $this;
+     */
+    public function setConstituencyService(Constituency $constituency)
+    {
+        $this->constituencyService = $constituency;
+        return $this;
+    }
+}

--- a/module/Althingi/src/Controller/Aggregate/ConstituencyController.php
+++ b/module/Althingi/src/Controller/Aggregate/ConstituencyController.php
@@ -17,10 +17,11 @@ class ConstituencyController extends AbstractRestfulController implements
     private $constituencyService;
 
     /**
+     * @param $id
      * @return ItemModel|\Rend\View\Model\ModelInterface
      * @output \Althingi\Model\Constituency
      */
-    public function get()
+    public function get($id)
     {
         return (new ItemModel(
             $this->constituencyService->get($this->params('constituency_id', null))

--- a/module/Althingi/src/Controller/Aggregate/PartyController.php
+++ b/module/Althingi/src/Controller/Aggregate/PartyController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Althingi\Controller\Aggregate;
+
+use Althingi\Injector\ServicePartyAwareInterface;
+use Althingi\Service\Party;
+use Rend\Controller\AbstractRestfulController;
+use Rend\View\Model\ItemModel;
+use Rend\Helper\Http\Range;
+
+class PartyController extends AbstractRestfulController implements
+    ServicePartyAwareInterface
+{
+    use Range;
+
+    /** @var $issueService \Althingi\Service\Party */
+    private $partyService;
+
+    /**
+     * @return ItemModel|\Rend\View\Model\ModelInterface
+     * @output \Althingi\Model\Party
+     */
+    public function get()
+    {
+        return (new ItemModel(
+            $this->partyService->get($this->params('party_id', null))
+        ));
+    }
+
+    /**
+     * @param \Althingi\Service\Party $party
+     * @return $this;
+     */
+    public function setPartyService(Party $party)
+    {
+        $this->partyService = $party;
+        return $this;
+    }
+}

--- a/module/Althingi/src/Controller/Aggregate/PartyController.php
+++ b/module/Althingi/src/Controller/Aggregate/PartyController.php
@@ -17,10 +17,11 @@ class PartyController extends AbstractRestfulController implements
     private $partyService;
 
     /**
+     * @param $id
      * @return ItemModel|\Rend\View\Model\ModelInterface
      * @output \Althingi\Model\Party
      */
-    public function get()
+    public function get($id)
     {
         return (new ItemModel(
             $this->partyService->get($this->params('party_id', null))

--- a/module/Althingi/src/Model/IssueProperties.php
+++ b/module/Althingi/src/Model/IssueProperties.php
@@ -27,6 +27,12 @@ class IssueProperties implements ModelInterface
     /** @var bool */
     private $governmentIssue = false;
 
+    /** @var string | null  */
+    private $document_type = null;
+
+    /** @var string | null  */
+    private $document_url = null;
+
     /** @var \Althingi\Model\Category[] */
     private $categories;
 
@@ -169,6 +175,42 @@ class IssueProperties implements ModelInterface
     }
 
     /**
+     * @return string|null
+     */
+    public function getDocumentType(): ?string
+    {
+        return $this->document_type;
+    }
+
+    /**
+     * @param string|null $document_type
+     * @return IssueProperties
+     */
+    public function setDocumentType(?string $document_type): IssueProperties
+    {
+        $this->document_type = $document_type;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDocumentUrl(): ?string
+    {
+        return $this->document_url;
+    }
+
+    /**
+     * @param string|null $document_url
+     * @return IssueProperties
+     */
+    public function setDocumentUrl(?string $document_url): IssueProperties
+    {
+        $this->document_url = $document_url;
+        return $this;
+    }
+
+    /**
      * @return Category[]
      */
     public function getCategories(): array
@@ -270,6 +312,8 @@ class IssueProperties implements ModelInterface
                 'proponents' => $this->proponents,
                 'speakers' => $this->speakers,
                 'government_issue' => $this->governmentIssue,
+                'document_type' => $this->document_type,
+                'document_url' => $this->document_url,
                 'categories' => $this->categories,
                 'super_categories' => $this->superCategory,
                 'issue_links' => $this->links,

--- a/module/Althingi/src/Store/Issue.php
+++ b/module/Althingi/src/Store/Issue.php
@@ -434,6 +434,8 @@ class Issue implements StoreAwareInterface
         $issueProperties = (new Model\IssueProperties())
             ->setSpeechCount($object->speech_count)
             ->setSpeechTime($object->speech_time)
+            ->setDocumentType($object->doument_type)
+            ->setDocumentUrl($object->document_url)
             ->setIssue($issue)
             ->setGovernmentIssue(isset($object->government_issue) ? $object->government_issue : false)
             ->setCategories(isset($object->categories) ? array_map(function ($category) {

--- a/module/Althingi/tests/Controller/IndexControllerTest.php
+++ b/module/Althingi/tests/Controller/IndexControllerTest.php
@@ -28,7 +28,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->dispatch('/', 'GET');
 
-        $this->assertControllerClass('IndexController');
+        $this->assertControllerName(\Althingi\Controller\IndexController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(200);
     }


### PR DESCRIPTION
## What?
Adds access to `Party` and `Constituency` through the `/samantekt` endpoint

It also adds two new properties to the `IssueProperties` model as they are available in the MongoDB storage

## How?
Adds `Controllers`, `Actions`, routes and config for `Party` and `Constituency` 

## Why?
They are needed for the **Accumulator**