### PR TITLE
Adds tests for mongo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,24 @@ RUN pecl install -o -f redis-4.3.0 \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable redis mongodb
 
+ARG WITH_XDEBUG=false
+
+RUN if [ $WITH_XDEBUG = "true" ] ; then \
+        pecl install xdebug; \
+        docker-php-ext-enable xdebug; \
+        echo "error_reporting = E_ALL" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+        echo "display_startup_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+        echo "display_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+        echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    fi ;
+
 COPY ./auto/php/php.ini /usr/local/etc/php/
 
 EXPOSE 80
 
 # with x-debug version
 #RUN pecl install -o -f redis \
-#    && pecl install xdebug-2.6.0 \
+#    && pecl install xdebug-2.8.0 \
 #    && rm -rf /tmp/pear \
 #    && docker-php-ext-enable redis xdebug
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
   | php -- --install-dir=/usr/local/bin --filename=composer
 
 RUN pecl install -o -f redis-4.3.0 \
-    && pecl install mongodb-1.5.3 \
+    && pecl install mongodb-1.6.0 \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable redis mongodb
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,7 @@ RUN apt-get update \
 
 RUN pecl install -o -f redis-4.3.0 \
     && pecl install xdebug-2.6.0 \
-    && pecl install mongodb-1.5.3 \
+    && pecl install mongodb-1.6.0 \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable redis xdebug mongodb
 

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,10 @@
         "monolog/monolog": "^1.23",
         "bramus/monolog-colored-line-formatter": "^2.0",
         "php-amqplib/php-amqplib": "^2.8",
-        "mongodb/mongodb": "1.1.2",
+        "mongodb/mongodb": "1.5.1",
         "zendframework/zend-progressbar": "^2.6",
-        "zendframework/zend-session": "^2.8"
+        "zendframework/zend-session": "^2.8",
+        "zumba/mongounit": "^4.0"
     },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d90fa9c994864df87434e36cdb5d629c",
+    "content-hash": "9b362a82b1701072caa4e49ca3be1343",
     "packages": [
         {
             "name": "bramus/ansi-php",
@@ -390,26 +390,36 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.1.2",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "a307dd60e71e1291c60927ea4f3a1905146063f5"
+                "reference": "32cfb9bbd0bc60a5a13ca9eab7e4803226a5d4a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/a307dd60e71e1291c60927ea4f3a1905146063f5",
-                "reference": "a307dd60e71e1291c60927ea4f3a1905146063f5",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/32cfb9bbd0bc60a5a13ca9eab7e4803226a5d4a7",
+                "reference": "32cfb9bbd0bc60a5a13ca9eab7e4803226a5d4a7",
                 "shasum": ""
             },
             "require": {
-                "ext-mongodb": "^1.2.0",
-                "php": ">=5.4"
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-mongodb": "^1.6",
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8"
+                "phpunit/phpunit": "^5.7.27 || ^6.4 || ^8.3",
+                "sebastian/comparator": "^1.0 || ^2.0 || ^3.0",
+                "squizlabs/php_codesniffer": "^3.4",
+                "symfony/phpunit-bridge": "^4.4@dev"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "MongoDB\\": "src/"
@@ -424,16 +434,16 @@
             ],
             "authors": [
                 {
+                    "name": "Andreas Braun",
+                    "email": "andreas.braun@mongodb.com"
+                },
+                {
                     "name": "Jeremy Mikola",
                     "email": "jmikola@gmail.com"
                 },
                 {
-                    "name": "Hannes Magnusson",
-                    "email": "bjori@mongodb.com"
-                },
-                {
-                    "name": "Derick Rethans",
-                    "email": "github@derickrethans.nl"
+                    "name": "Katherine Walker",
+                    "email": "katherine.walker@mongodb.com"
                 }
             ],
             "description": "MongoDB driver library",
@@ -444,7 +454,7 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2017-02-16T18:40:32+00:00"
+            "time": "2019-10-09T14:34:41+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2768,6 +2778,55 @@
                 "annotations"
             ],
             "time": "2013-05-29T02:35:23+00:00"
+        },
+        {
+            "name": "zumba/mongounit",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zumba/mongounit.git",
+                "reference": "541b07d2bf3f9c98583519c7556789d645317e08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zumba/mongounit/zipball/541b07d2bf3f9c98583519c7556789d645317e08",
+                "reference": "541b07d2bf3f9c98583519c7556789d645317e08",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mongodb": "^1.6.0",
+                "mongodb/mongodb": "^1.5",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Zumba\\PHPUnit\\Extensions\\Mongo\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Saylor",
+                    "email": "christopher.saylor@zumba.com",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHPUnit extension that supports mongodb",
+            "homepage": "https://github.com/zumba/mongounit",
+            "keywords": [
+                "database",
+                "mongoclient",
+                "mongodb",
+                "testing"
+            ],
+            "time": "2019-11-04T22:45:09+00:00"
         }
     ],
     "packages-dev": [
@@ -2878,12 +2937,12 @@
             "version": "v1.6.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "shasum": ""
             },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - ./module/:/var/www/module
       - ./public/:/var/www/public
     environment:
+
       - LOG_PATH=php://stdout
       - LOG_FORMAT=line
 
@@ -72,9 +73,12 @@ services:
       dockerfile: Dockerfile.test
     depends_on:
       - database
+      - store
     links:
       - database
+      - store
     environment:
+      - WITH_XDEBUG=true
       - APPLICATION_ENVIRONMENT=development
       - DB_HOST=database
       - DB_PORT=3306
@@ -88,6 +92,8 @@ services:
       - LOG_PATH=none
       - QUEUE=none
       - QUEUE_FORCED=false
+      - STORAGE_HOST=store
+      - STORAGE_DB=althingi
     volumes:
       - ./auto/:/usr/src/auto
       - ./config/:/usr/src/config
@@ -104,3 +110,7 @@ services:
       - ./auto/db/:/docker-entrypoint-initdb.d
     environment:
       - MYSQL_ROOT_PASSWORD=example
+
+  store:
+    container_name: althingi_test_store
+    image: mongo:4.2.0-bionic

--- a/module/Althingi/config/module.config.php
+++ b/module/Althingi/config/module.config.php
@@ -913,15 +913,8 @@ return [
             },
             Controller\IssueController::class => function (ServiceManager $container) {
                 return (new Controller\IssueController())
-                    ->setPartyService($container->get(Service\Party::class))
-                    ->setCongressmanService($container->get(Service\Congressman::class))
                     ->setAssemblyService($container->get(Service\Assembly::class))
                     ->setIssueService($container->get(Service\Issue::class))
-                    ->setSpeechService($container->get(Service\Speech::class))
-                    ->setVoteService($container->get(Service\Vote::class))
-                    ->setDocumentService($container->get(Service\Document::class))
-                    ->setSearchIssueService($container->get(Service\SearchIssue::class))
-                    ->setConstituencyService($container->get(Service\Constituency::class))
                     ->setCategoryService($container->get(Service\Category::class))
                     ->setIssueStore($container->get(Store\Issue::class))
                     ->setCategoryStore($container->get(Store\Category::class))
@@ -938,7 +931,6 @@ return [
                     ->setPartyService($container->get(Service\Party::class))
                     ->setPlenaryService($container->get(Service\Plenary::class))
                     ->setConstituencyService($container->get(Service\Constituency::class))
-                    ->setSearchSpeechService($container->get(Service\SearchSpeech::class))
                     ->setSpeechStore($container->get(Store\Speech::class));
             },
             Controller\VoteController::class => function (ServiceManager $container) {

--- a/module/Althingi/src/Controller/AssemblyController.php
+++ b/module/Althingi/src/Controller/AssemblyController.php
@@ -216,8 +216,18 @@ class AssemblyController extends AbstractRestfulController implements
     public function statisticsAction()
     {
         $assembly = $this->assemblyService->get($this->params('id'));
-//        $response = $this->fetchStatisticsFromService($assembly);
-        $response = $this->fetchStatisticsFromStore($assembly);
+        $response = (new Model\AssemblyStatusProperties())
+            ->setVotes($this->voteStore->fetchFrequencyByAssembly($assembly->getAssemblyId()))
+            ->setSpeeches($this->speechStore->fetchFrequencyByAssembly($assembly->getAssemblyId()))
+            ->setAverageAge($this->congressmanStore->getAverageAgeByAssembly(
+                $assembly->getAssemblyId(),
+                $assembly->getFrom()
+            ))
+            ->setPartyTimes($this->partyStore->fetchTimeByAssembly($assembly->getAssemblyId()))
+//            ->setElection($this->electionService->getByAssembly($assembly->getAssemblyId()))
+            ->setElection(null)
+            ->setElectionResults([])
+        ;
 
         return (new ItemModel($response))
             ->setStatus(200)
@@ -424,59 +434,6 @@ class AssemblyController extends AbstractRestfulController implements
     {
         $this->categoryStore = $category;
         return $this;
-    }
-
-    /**
-     * Gets Statistics from Service ie. DB.
-     *
-     * @param Model\Assembly $assembly
-     * @return Model\AssemblyStatusProperties
-     * @deprecated
-     */
-    private function fetchStatisticsFromService(Model\Assembly $assembly)
-    {
-        return (new Model\AssemblyStatusProperties())
-            ->setVotes(DateAndCountSequence::buildDateRange(
-                $assembly->getFrom(),
-                $assembly->getTo(),
-                $this->voteService->fetchFrequencyByAssembly($assembly->getAssemblyId())
-            ))
-            ->setSpeeches(DateAndCountSequence::buildDateRange(
-                $assembly->getFrom(),
-                $assembly->getTo(),
-                $this->speechService->fetchFrequencyByAssembly($assembly->getAssemblyId(), ['A', 'B'])
-            ))
-            ->setAverageAge($this->congressmanService->getAverageAgeByAssembly(
-                $assembly->getAssemblyId(),
-                $assembly->getFrom()
-            ))
-            ->setPartyTimes($this->partyService->fetchTimeByAssembly($assembly->getAssemblyId(), ['A', 'B']))
-            ->setElection($this->electionService->getByAssembly($assembly->getAssemblyId()))
-            ->setElectionResults($this->partyService->fetchElectedByAssembly($assembly->getAssemblyId()))
-        ;
-    }
-
-    /**
-     * Gets Statistics from Service ie. MongoDB.
-     *
-     * @param Model\Assembly $assembly
-     * @return Model\AssemblyStatusProperties
-     * @todo the Election results are not being fetched at all.
-     */
-    private function fetchStatisticsFromStore(Model\Assembly $assembly)
-    {
-        return (new Model\AssemblyStatusProperties())
-            ->setVotes($this->voteStore->fetchFrequencyByAssembly($assembly->getAssemblyId()))
-            ->setSpeeches($this->speechStore->fetchFrequencyByAssembly($assembly->getAssemblyId()))
-            ->setAverageAge($this->congressmanStore->getAverageAgeByAssembly(
-                $assembly->getAssemblyId(),
-                $assembly->getFrom()
-            ))
-            ->setPartyTimes($this->partyStore->fetchTimeByAssembly($assembly->getAssemblyId()))
-
-            ->setElection(null)
-            ->setElectionResults([])
-        ;
     }
 
     /**

--- a/module/Althingi/src/Controller/SpeechController.php
+++ b/module/Althingi/src/Controller/SpeechController.php
@@ -27,7 +27,6 @@ class SpeechController extends AbstractRestfulController implements
     ServiceSpeechAwareInterface,
     ServiceCongressmanAwareInterface,
     ServicePartyAwareInterface,
-    ServiceSearchSpeechAwareInterface,
     ServicePlenaryAwareInterface,
     ServiceConstituencyAwareInterface,
     StoreSpeechAwareInterface
@@ -39,9 +38,6 @@ class SpeechController extends AbstractRestfulController implements
 
     /** @var \Althingi\Store\Speech */
     private $speechStore;
-
-    /** @var  \Althingi\Service\SearchSpeech */
-    private $speechSearch;
 
     /** @var \Althingi\Service\Congressman */
     private $congressmanService;
@@ -314,16 +310,6 @@ class SpeechController extends AbstractRestfulController implements
     public function setSpeechService(Service\Speech $speech)
     {
         $this->speechService = $speech;
-        return $this;
-    }
-
-    /**
-     * @param \Althingi\Service\SearchSpeech $speech
-     * @return $this
-     */
-    public function setSearchSpeechService(Service\SearchSpeech $speech)
-    {
-        $this->speechSearch = $speech;
         return $this;
     }
 

--- a/module/Althingi/src/Store/Issue.php
+++ b/module/Althingi/src/Store/Issue.php
@@ -36,7 +36,7 @@ class Issue implements StoreAwareInterface
      * @param array $types
      * @param array $kinds
      * @param array $categories
-     * @return array
+     * @return Model\IssueProperties[]
      */
     public function fetchByAssembly(
         int $assemblyId,
@@ -47,7 +47,7 @@ class Issue implements StoreAwareInterface
         array $categories = ['A', 'B']
     ): array {
         $criteria = array_merge(
-            ['issue.assembly_id' => $assemblyId],
+            ['assembly.assembly_id' => $assemblyId],
             ['issue.category' => ['$in' => $categories]],
             count($types) ? ['issue.type' => ['$in' => $types]] : [],
             count($kinds) ? ['categories.category_id' => ['$in' => $kinds]] : []
@@ -439,8 +439,8 @@ class Issue implements StoreAwareInterface
         $issueProperties = (new Model\IssueProperties())
             ->setSpeechCount($object->speech_count)
             ->setSpeechTime($object->speech_time)
-            ->setDocumentType($object->document_type)
-            ->setDocumentUrl($object->document_url)
+            ->setDocumentType(property_exists($object, 'document_type') ? $object->document_type : null)
+            ->setDocumentUrl(property_exists($object, 'document_url') ? $object->document_url : null)
             ->setIssue($issue)
             ->setGovernmentIssue(isset($object->government_issue) ? $object->government_issue : false)
             ->setCategories(isset($object->categories) ? array_map(function ($category) {

--- a/module/Althingi/src/Store/Speech.php
+++ b/module/Althingi/src/Store/Speech.php
@@ -22,7 +22,7 @@ class Speech implements StoreAwareInterface
      * @param int|null $offset
      * @param int|null $size
      * @param int|null $words
-     * @return array
+     * @return \Althingi\Model\SpeechCongressmanProperties[]
      */
     public function fetchByIssue(
         $assemblyId,

--- a/module/Althingi/tests/Controller/AggregateDocumentControllerTest.php
+++ b/module/Althingi/tests/Controller/AggregateDocumentControllerTest.php
@@ -14,7 +14,6 @@ use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
  * @coversDefaultClass \Althingi\Controller\Aggregate\DocumentController
  * @covers \Althingi\Controller\Aggregate\DocumentController::setDocumentService
  * @covers \Althingi\Controller\Aggregate\DocumentController::setCongressmanDocumentService
-
  */
 class AggregateDocumentControllerTest extends AbstractHttpControllerTestCase
 {

--- a/module/Althingi/tests/Controller/AssemblyControllerTest.php
+++ b/module/Althingi/tests/Controller/AssemblyControllerTest.php
@@ -5,6 +5,7 @@ namespace AlthingiTest\Controller;
 use Althingi\Service;
 use Althingi\Model;
 use Althingi\Store;
+use Althingi\Controller\AssemblyController;
 use AlthingiTest\ServiceHelper;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use DateTime;
@@ -51,7 +52,14 @@ class AssemblyControllerTest extends AbstractHttpControllerTestCase
             Service\Cabinet::class,
             Service\Category::class,
             Service\Election::class,
-            Store\Assembly::class
+            Service\Congressman::class,
+            Store\Assembly::class,
+            Store\Issue::class,
+            Store\Vote::class,
+            Store\Speech::class,
+            Store\Party::class,
+            Store\Category::class,
+            Store\Congressman::class
         ]);
     }
 
@@ -67,15 +75,6 @@ class AssemblyControllerTest extends AbstractHttpControllerTestCase
      */
     public function testGet()
     {
-//        $this->getMockService(Store\Assembly::class)
-//            ->shouldReceive('get')
-//            ->andReturn((new Model\AssemblyProperties())
-//                ->setAssembly((new Model\Assembly())
-//                    ->setAssemblyId(144)
-//                    ->setFrom(new DateTime())))
-//            ->once()
-//            ->getMock();
-
         $this->getMockService(Service\Assembly::class)
             ->shouldReceive('get')
             ->andReturn((new Model\Assembly())
@@ -106,7 +105,7 @@ class AssemblyControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/loggjafarthing/144', 'GET');
 
-        $this->assertControllerClass('AssemblyController');
+        $this->assertControllerName(AssemblyController::class);
         $this->assertActionName('get');
         $this->assertResponseStatusCode(200);
     }
@@ -116,12 +115,6 @@ class AssemblyControllerTest extends AbstractHttpControllerTestCase
      */
     public function testGetNotFound()
     {
-//        $this->getMockService(Store\Assembly::class)
-//            ->shouldReceive('get')
-//            ->andReturn(null)
-//            ->once()
-//            ->getMock();
-
         $this->getMockService(Service\Assembly::class)
             ->shouldReceive('get')
             ->andReturn(null)

--- a/module/Althingi/tests/Controller/IssueControllerTest.php
+++ b/module/Althingi/tests/Controller/IssueControllerTest.php
@@ -2,22 +2,11 @@
 
 namespace AlthingiTest\Controller;
 
-use Althingi\Model\ConstituencyDate;
-use Althingi\Model\Proponent;
-use Althingi\Service\Assembly;
-use Althingi\Service\Congressman;
-use Althingi\Service\Constituency;
-use Althingi\Service\Document;
-use Althingi\Service\Issue;
-use Althingi\Service\Party;
-use Althingi\Service\Speech;
-use Althingi\Service\Vote;
-use Althingi\Model\CongressmanAndDateRange;
-use Althingi\Model\Issue as IssueModel;
-use Althingi\Model\Party as PartyModel;
-use Althingi\Model\Assembly as AssemblyModel;
-use Althingi\Model\IssueAndDate as IssueAndDateModel;
-use Althingi\Model\IssueValue as IssueValueModel;
+use Althingi\Service;
+use Althingi\Store;
+use Althingi\Model;
+use Althingi\Controller;
+
 use AlthingiTest\ServiceHelper;
 use Mockery;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
@@ -52,14 +41,11 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
         parent::setUp();
 
         $this->buildServices([
-            Congressman::class,
-            Issue::class,
-            Party::class,
-            Document::class,
-            Vote::class,
-            Assembly::class,
-            Speech::class,
-            Constituency::class,
+            Service\Issue::class,
+            Service\Assembly::class,
+            Service\Category::class,
+            Store\Issue::class,
+            Store\Category::class,
         ]);
     }
 
@@ -73,285 +59,111 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
      * @covers ::get
      * @pending mongodb test framework
      */
-//    public function testGetSuccessA()
-//    {
-//        $this->getMockService(Issue::class)
-//            ->shouldReceive('getWithDate')
-//            ->andReturn((new IssueAndDateModel())->setCategory('A')->setCongressmanId(1)->setDate(new \DateTime()))
-//            ->once()
-//            ->with(200, 100, 'A')
-//            ->getMock();
-//
-//        $this->getMockService(Assembly::class)
-//            ->shouldReceive('get')
-//            ->andReturn((new AssemblyModel)->setFrom(new \DateTime('2001-02-01')))
-//            ->never()
-//            ->with(100)
-//            ->getMock();
-//
-//        $this->getMockService(Congressman::class)
-//            ->shouldReceive('fetchProponentsByIssue')
-//            ->andReturn([(new Proponent())->setCongressmanId(1)])
-//            ->once()
-//            ->with(100, 200)
-//            ->getMock()
-//
-//            ->shouldReceive('fetchAccumulatedTimeByIssue')
-//            ->andReturn([(new CongressmanAndDateRange())->setBegin(new \DateTime())->setCongressmanId(1)])
-//            ->once()
-//            ->with(100, 200, 'A')
-//            ->getMock();
-//
-//        $this->getMockService(Party::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn((new PartyModel()))
-//            ->twice()
-//            ->getMock();
-//
-//        $this->getMockService(Vote::class)
-//            ->shouldReceive('fetchDateFrequencyByIssue')
-//            ->andReturn([])
-//            ->once()
-//            ->with(100, 200)
-//            ->getMock();
-//
-//        $this->getMockService(Speech::class)
-//            ->shouldReceive('fetchFrequencyByIssue')
-//            ->andReturn([])
-//            ->once()
-//            ->with(100, 200, 'A')
-//            ->getMock();
-//
-//        $this->getMockService(Constituency::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn(new ConstituencyDate())
-//            ->twice()
-//            ->getMock();
-//
-//
-//        $this->dispatch('/loggjafarthing/100/thingmal/a/200', 'GET');
-//
-//        $this->assertControllerName(\Althingi\Controller\IssueController::class);
-//        $this->assertActionName('get');
-//        $this->assertResponseStatusCode(200);
-//    }
+    public function testGetSuccessA()
+    {
+        $this->getMockService(Store\Issue::class)
+            ->shouldReceive('get')
+            ->with(100, 200, 'A')
+            ->andReturn((new Model\IssueProperties())->setIssue(new Model\Issue()))
+            ->getMock();
+
+        $this->dispatch('/loggjafarthing/100/thingmal/a/200', 'GET');
+
+        $this->assertControllerName(Controller\IssueController::class);
+        $this->assertActionName('get');
+        $this->assertResponseStatusCode(200);
+    }
 
     /**
      * @covers ::get
      * @pending mongodb test framework
      */
-//    public function testGetSuccessB()
-//    {
-//        $this->getMockService(Issue::class)
-//            ->shouldReceive('getWithDate')
-//            ->andReturn((new IssueAndDateModel())->setCategory('B')->setCongressmanId(1)->setDate(new \DateTime()))
-//            ->once()
-//            ->with(200, 100, 'B')
-//            ->getMock();
-//
-//        $this->getMockService(Assembly::class)
-//            ->shouldReceive('get')
-//            ->andReturn((new AssemblyModel)->setFrom(new \DateTime('2001-02-01')))
-//            ->never()
-//            ->with(100)
-//            ->getMock();
-//
-//        $this->getMockService(Congressman::class)
-//            ->shouldReceive('fetchProponentsByIssue')
-//            ->andReturn([(new Proponent())->setCongressmanId(1)])
-//            ->never()
-//            ->with(100, 200)
-//            ->getMock()
-//
-//            ->shouldReceive('fetchAccumulatedTimeByIssue')
-//            ->andReturn([(new CongressmanAndDateRange())->setBegin(new \DateTime())->setCongressmanId(1)])
-//            ->once()
-//            ->with(100, 200, 'B')
-//            ->getMock();
-//
-//        $this->getMockService(Party::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn((new PartyModel()))
-//            ->once()
-//            ->getMock();
-//
-//        $this->getMockService(Vote::class)
-//            ->shouldReceive('fetchDateFrequencyByIssue')
-//            ->andReturn([])
-//            ->never()
-//            ->with(100, 200)
-//            ->getMock();
-//
-//        $this->getMockService(Speech::class)
-//            ->shouldReceive('fetchFrequencyByIssue')
-//            ->andReturn([])
-//            ->once()
-//            ->with(100, 200, 'B')
-//            ->getMock();
-//
-//        $this->getMockService(Constituency::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn(new ConstituencyDate())
-//            ->once()
-//            ->getMock();
-//
-//
-//        $this->dispatch('/loggjafarthing/100/thingmal/b/200', 'GET');
-//
-//        $this->assertControllerName(\Althingi\Controller\IssueController::class);
-//        $this->assertActionName('get');
-//        $this->assertResponseStatusCode(200);
-//    }
+    public function testGetSuccessB()
+    {
+        $this->getMockService(Store\Issue::class)
+            ->shouldReceive('get')
+            ->with(100, 200, 'B')
+            ->andReturn((new Model\IssueProperties())->setIssue(new Model\Issue()))
+            ->getMock();
+
+        $this->dispatch('/loggjafarthing/100/thingmal/b/200', 'GET');
+
+        $this->assertControllerName(Controller\IssueController::class);
+        $this->assertActionName('get');
+        $this->assertResponseStatusCode(200);
+    }
 
     /**
      * @covers ::speechTimesAction
      * @pending mongodb test framework
      */
-//    public function testGetSpeechTime()
-//    {
-//        $this->getMockService(Assembly::class)
-//            ->shouldReceive('get')
-//            ->andReturn((new \Althingi\Model\Assembly())->setAssemblyId(1)->setFrom(new \DateTime()))
-//            ->once()
-//            ->getMock()
-//        ;
-//
-//        $this->getMockService(Issue::class)
-//            ->shouldReceive('fetchByAssemblyAndSpeechTime')
-//            ->andReturn(array_map(function ($i) {
-//                return (new IssueValueModel())->setCongressmanId(1)->setCategory('A')->setIssueId($i)->setValue($i);
-//            }, range(0, 24)))
-//            ->once()
-//            ->getMock()
-//        ;
-//
-//        $this->getMockService(Party::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn(null)
-//            ->times(25)
-//            ->getMock()
-//        ;
-//
-//        $this->getMockService(Congressman::class)
-//            ->shouldReceive('fetchProponentsByIssue')
-//            ->andReturn([(new Proponent())->setCongressmanId(1)])
-//            ->times(25)
-//            ->getMock()
-//        ;
-//
-//        $this->dispatch('/loggjafarthing/100/thingmal/a/raedutimar', 'GET');
-//
-//        $this->assertControllerName(\Althingi\Controller\IssueController::class);
-//        $this->assertActionName('speech-times');
-//        $this->assertResponseStatusCode(206);
-//    }
+    public function testGetSpeechTime()
+    {
+        $this->getMockService(Store\Issue::class)
+            ->shouldReceive('fetchByAssemblyAndSpeechTime')
+            ->with(100, 5, 1, ['A'])
+            ->andReturn([])
+            ->getMock();
+
+        $this->dispatch('/loggjafarthing/100/thingmal/a/raedutimar', 'GET');
+
+        $this->assertControllerName(Controller\IssueController::class);
+        $this->assertActionName('speech-times');
+        $this->assertResponseStatusCode(206);
+    }
 
     /**
      * @covers ::get
      * @pending mongodb test framework
      */
-//    public function testGetNotFound()
-//    {
-//        $this->getMockService(Issue::class)
-//            ->shouldReceive('getWithDate')
-//            ->andReturn(null)
-//            ->once()
-//            ->getMock();
-//
-//        $this->getMockService(Assembly::class)
-//            ->shouldReceive('get')
-//            ->never()
-//            ->getMock();
-//
-//        $this->getMockService(Congressman::class)
-//            ->shouldReceive('get')
-//            ->never()
-//            ->getMock()
-//            ->shouldReceive('fetchAccumulatedTimeByIssue')
-//            ->never()
-//            ->getMock();
-//
-//        $this->getMockService(Party::class)
-//            ->shouldReceive('getByCongressman')
-//            ->never()
-//            ->getMock();
-//
-//        $this->getMockService(Vote::class)
-//            ->shouldReceive('fetchDateFrequencyByIssue')
-//            ->never()
-//            ->getMock();
-//
-//        $this->getMockService(Speech::class)
-//            ->shouldReceive('fetchFrequencyByIssue')
-//            ->never()
-//            ->getMock();
-//
-//
-//        $this->dispatch('/loggjafarthing/100/thingmal/a/200', 'GET');
-//
-//        $this->assertControllerName(\Althingi\Controller\IssueController::class);
-//        $this->assertActionName('get');
-//        $this->assertResponseStatusCode(404);
-//    }
+    public function testGetNotFound()
+    {
+        $this->getMockService(Store\Issue::class)
+            ->shouldReceive('get')
+            ->with(100, 200, 'A')
+            ->andReturn(null)
+            ->getMock();
+
+        $this->dispatch('/loggjafarthing/100/thingmal/a/200', 'GET');
+
+        $this->assertControllerName(Controller\IssueController::class);
+        $this->assertActionName('get');
+        $this->assertResponseStatusCode(404);
+    }
 
     /**
      * @covers ::getList
      * @pending mongodb test framework
      */
-//    public function testGetList()
-//    {
-//        $this->getMockService(Issue::class)
-//            ->shouldReceive('countByAssembly')
-//            ->andReturn(123)
-//            ->once()
-//            ->getMock()
-//            ->shouldReceive('fetchByAssembly')
-//            ->andReturn(array_map(function () {
-//                    return (new IssueAndDateModel())
-//                        ->setDate(new \DateTime())
-//                        ->setCategory('A')
-//                        ->setCongressmanId(1)
-//                        ->setIssueId(1);
-//            }, range(0, 24)))
-//            ->once()
-//            ->getMock()
-//        ;
-//
-//        $this->getMockService(Party::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn(null)
-//            ->times(25)
-//            ->getMock()
-//        ;
-//
-//        $this->getMockService(Congressman::class)
-//            ->shouldReceive('fetchProponentsByIssue')
-//            ->andReturn([(new Proponent())->setCongressmanId(1)])
-//            ->times(25)
-//            ->getMock()
-//        ;
-//
-//        $this->getMockService(Constituency::class)
-//            ->shouldReceive('getByCongressman')
-//            ->andReturn(new ConstituencyDate())
-//            ->times(25)
-//            ->getMock();
-//
-//        $this->dispatch('/loggjafarthing/100/thingmal', 'GET');
-//
-//        $this->assertControllerName(\Althingi\Controller\IssueController::class);
-//        $this->assertActionName('getList');
-//        $this->assertResponseStatusCode(206);
-//        $this->assertResponseHeaderContains('Range-Unit', 'items');
-//        $this->assertResponseHeaderContains('Content-Range', 'items 0-25/123');
-//    }
+    public function testGetList()
+    {
+        $this->getMockService(Store\Issue::class)
+            ->shouldReceive('fetchByAssembly')
+            ->with(100, 0, null, [], [], ['A', 'B'])
+            ->andReturn(array_map(function () {
+                (new Model\IssueProperties())->setIssue(new Model\Issue());
+            }, range(0, 24)))
+            ->getMock()
+
+            ->shouldReceive('countByAssembly')
+            ->andReturn(123)
+            ->getMock();
+
+        $this->dispatch('/loggjafarthing/100/thingmal', 'GET');
+
+        $this->assertControllerName(Controller\IssueController::class);
+        $this->assertActionName('getList');
+        $this->assertResponseStatusCode(206);
+        $this->assertResponseHeaderContains('Range-Unit', 'items');
+        $this->assertResponseHeaderContains('Content-Range', 'items 0-25/123');
+    }
 
     /**
      * @covers ::put
      */
     public function testPutSuccess()
     {
-        $expectedObject = (new IssueModel())
+        $expectedObject = (new Model\Issue())
             ->setIssueId(200)
             ->setAssemblyId(100)
             ->setCategory('A')
@@ -361,7 +173,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             ->setTypeSubname('tsn')
         ;
 
-        $this->getMockService(Issue::class)
+        $this->getMockService(Service\Issue::class)
             ->shouldReceive('save')
             ->with(Mockery::on(function ($actualObject) use ($expectedObject) {
                 return $expectedObject == $actualObject;
@@ -379,7 +191,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             'type_subname' => 'tsn',
         ]);
 
-        $this->assertControllerName(\Althingi\Controller\IssueController::class);
+        $this->assertControllerName(Controller\IssueController::class);
         $this->assertActionName('put');
         $this->assertResponseStatusCode(201);
     }
@@ -389,7 +201,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
      */
     public function testPutInvalidForm()
     {
-        $this->getMockService(Issue::class)
+        $this->getMockService(Service\Issue::class)
             ->shouldReceive('create')
             ->never()
             ->getMock()
@@ -400,7 +212,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             'type_subname' => 'tsn',
         ]);
 
-        $this->assertControllerName(\Althingi\Controller\IssueController::class);
+        $this->assertControllerName(Controller\IssueController::class);
         $this->assertActionName('put');
         $this->assertResponseStatusCode(400);
     }
@@ -410,7 +222,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
      */
     public function testPatch()
     {
-        $expectedObject = (new IssueModel())
+        $expectedObject = (new Model\Issue())
             ->setIssueId(200)
             ->setAssemblyId(100)
             ->setName('n1')
@@ -420,11 +232,11 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             ->setTypeSubname('tsn')
         ;
 
-        $this->getMockService(Issue::class)
+        $this->getMockService(Service\Issue::class)
             ->shouldReceive('get')
             ->once()
             ->with(200, 100, 'A')
-            ->andReturn((new IssueModel())->setIssueId(200)->setAssemblyId(100)->setCategory('A'))
+            ->andReturn((new Model\Issue())->setIssueId(200)->setAssemblyId(100)->setCategory('A'))
             ->getMock()
 
             ->shouldReceive('update')
@@ -444,7 +256,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
             'type_subname' => 'tsn',
         ]);
 
-        $this->assertControllerName(\Althingi\Controller\IssueController::class);
+        $this->assertControllerName(Controller\IssueController::class);
         $this->assertActionName('patch');
         $this->assertResponseStatusCode(205);
     }
@@ -456,7 +268,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
     {
         $this->dispatch('/loggjafarthing/100/thingmal', 'OPTIONS');
 
-        $this->assertControllerName(\Althingi\Controller\IssueController::class);
+        $this->assertControllerName(Controller\IssueController::class);
         $this->assertActionName('optionslist');
         $this->assertResponseStatusCode(200);
 
@@ -476,7 +288,7 @@ class IssueControllerTest extends AbstractHttpControllerTestCase
     {
         $this->dispatch('/loggjafarthing/100/thingmal/a/200', 'OPTIONS');
 
-        $this->assertControllerName(\Althingi\Controller\IssueController::class);
+        $this->assertControllerName(Controller\IssueController::class);
         $this->assertActionName('options');
         $this->assertResponseStatusCode(200);
 

--- a/module/Althingi/tests/Controller/PlenaryAgendaControllerTest.php
+++ b/module/Althingi/tests/Controller/PlenaryAgendaControllerTest.php
@@ -2,6 +2,9 @@
 
 namespace AlthingiTest\Controller;
 
+use Althingi\Service\Congressman;
+use Althingi\Service\Issue;
+use Althingi\Service\Party;
 use Althingi\Service\Plenary;
 use Althingi\Service\PlenaryAgenda;
 use AlthingiTest\ServiceHelper;
@@ -31,6 +34,10 @@ class PlenaryAgendaControllerTest extends AbstractHttpControllerTestCase
 
         $this->buildServices([
             PlenaryAgenda::class,
+            Plenary::class,
+            Issue::class,
+            Congressman::class,
+            Party::class,
         ]);
     }
 
@@ -66,7 +73,7 @@ class PlenaryAgendaControllerTest extends AbstractHttpControllerTestCase
             'category' => 'B',
         ]);
 
-        $this->assertControllerClass('PlenaryAgendaController');
+        $this->assertControllerName(\Althingi\Controller\PlenaryAgendaController::class);
         $this->assertActionName('put');
         $this->assertResponseStatusCode(201);
     }

--- a/module/Althingi/tests/Controller/VoteItemControllerTest.php
+++ b/module/Althingi/tests/Controller/VoteItemControllerTest.php
@@ -3,7 +3,10 @@
 namespace AlthingiTest\Controller;
 
 use Althingi\Model\VoteItemAndAssemblyIssue;
+use Althingi\Service\Congressman;
 use Althingi\Service\Constituency;
+use Althingi\Service\Party;
+use Althingi\Service\Vote;
 use Althingi\Service\VoteItem;
 use AlthingiTest\ServiceHelper;
 use Mockery;
@@ -33,7 +36,10 @@ class VoteItemControllerTest extends AbstractHttpControllerTestCase
 
         $this->buildServices([
             VoteItem::class,
-            Constituency::class
+            Vote::class,
+            Constituency::class,
+            Congressman::class,
+            Party::class,
         ]);
     }
 

--- a/module/Althingi/tests/StorageConnection.php
+++ b/module/Althingi/tests/StorageConnection.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AlthingiTest;
+
+use Zumba\PHPUnit\Extensions\Mongo\Client\Connector;
+use Zumba\PHPUnit\Extensions\Mongo\TestTrait;
+use MongoDB\Client;
+
+trait StorageConnection
+{
+    use TestTrait;
+
+    /**
+     * @var \Zumba\PHPUnit\Extensions\Mongo\Client\Connector
+     */
+    static protected $connection;   // phpcs:ignore
+
+    /** @var \MongoDB\Database; */
+    protected $database;
+
+    /**
+     * @return \Zumba\PHPUnit\Extensions\Mongo\Client\Connector
+     */
+    public function getMongoConnection()
+    {
+        $host = getenv('STORAGE_HOST') ?: 'store';
+        $database = getenv('STORAGE_DB') ?: 'althingi';
+
+        if (empty(self::$connection)) {
+            self::$connection = new Connector(new Client("mongodb://{$host}/"));
+            self::$connection->setDb($database);
+        }
+        $this->database = self::$connection->getConnection()->selectDatabase($database);
+        return self::$connection;
+    }
+}

--- a/module/Althingi/tests/Store/IssueTest.php
+++ b/module/Althingi/tests/Store/IssueTest.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace AlthingiTest\Store;
+
+use AlthingiTest\StorageConnection;
+use Althingi\Store;
+use Althingi\Model;
+use PHPUnit\Framework\TestCase;
+use Zumba\PHPUnit\Extensions\Mongo\DataSet\DataSet;
+
+class IssueTest extends TestCase
+{
+    use StorageConnection;
+
+    public function testGet()
+    {
+        $store = (new Store\Issue())->setStore($this->database);
+        $issue = $store->get(149, 1, 'A');
+        $this->assertInstanceOf(Model\IssueProperties::class, $issue);
+    }
+
+    public function testGetNotFound()
+    {
+        $store = (new Store\Issue())->setStore($this->database);
+        $issue = $store->get(1, 1, 'A');
+        $this->assertNull($issue);
+    }
+
+    public function testFetchByAssembly()
+    {
+        $store = (new Store\Issue())->setStore($this->database);
+        $issues = $store->fetchByAssembly(149);
+        $this->assertCount(2, $issues);
+    }
+
+    public function testFetchAByAssembly()
+    {
+        $store = (new Store\Issue())->setStore($this->database);
+        $issues = $store->fetchByAssembly(149, 0, 10, [], [], ['A']);
+        $this->assertCount(1, $issues);
+    }
+
+    public function testCountByAssembly()
+    {
+        $store = (new Store\Issue())->setStore($this->database);
+        $issues = $store->countByAssembly(149, [], [], ['A']);
+        $this->assertEquals(1, $issues);
+    }
+
+    /**
+     * Retrieve a DataSet object.
+     *
+     * @return \Zumba\PHPUnit\Extensions\Mongo\DataSet\DataSet
+     */
+    protected function getMongoDataSet()
+    {
+        $dataSet = new DataSet($this->getMongoConnection());
+        $dataSet->setFixture([
+            'issue' => [
+                [
+
+                    "assembly" => [
+                        "assembly_id" => 149
+                    ],
+                    "issue" => [
+                        "issue_id" => 1,
+                        "assembly_id" => 149,
+                        "congressman_id" => null,
+                        "category" => "A",
+                        "name" => "fjárlög 2019",
+                        "sub_name" => null,
+                        "type" => "l",
+                        "type_name" => "Frumvarp til laga",
+                        "type_subname" => "lagafrumvarp",
+                        "status" => "Samþykkt sem lög frá Alþingi",
+                        "question" => null,
+                        "goal" => "selja fasteignir.",
+                        "major_changes" => "Lögð eru til aukin framlög til ",
+                        "changes_in_law" => "Gera þarf ",
+                        "costs_and_revenues" => "Áætlað er að tekjur fyrir ",
+                        "deliveries" => "Frumvarpið varð að lögum með þeim ",
+                        "additional_information" => ""
+                    ],
+                    "categories" => [
+                        [
+                            "category_id" => 6,
+                            "super_category_id" => 2,
+                            "title" => "Fjárreiður ríkisins",
+                            "description" => "þ.m.t. fjárlög, lánamál "
+                        ]
+                    ],
+                    "date" => null,
+                    "government_issue" => true,
+                    "proponents" => [
+                        [
+                            "congressman" => [
+                                "congressman_id" => 652,
+                                "name" => "Bjarni Benediktsson",
+                                "birth" => "1970-01-26",
+                                "death" => null,
+                                "abbreviation" => "BjarnB",
+                                "party" => [
+                                    "party_id" => 35,
+                                    "name" => "Sjálfstæðisflokkur",
+                                    "abbr_short" => "S",
+                                    "abbr_long" => "Sjálfstfl.",
+                                    "color" => "00adef"
+                                ],
+                                "assembly" => null,
+                                "constituency" => [
+                                    "constituency_id" => 52,
+                                    "name" => "Suðvesturkjördæmi",
+                                    "abbr_short" => "SV",
+                                    "abbr_long" => "Suðvest.",
+                                    "description" => "Til þess teljast efti",
+                                    "date" => "2018-09-11"
+                                ]
+                            ],
+                            "order" => 1,
+                            "minister" => "fjármála- og efnahagsráðherra"
+                        ]
+                    ],
+                    "speakers" => [],
+                    "speech_count" => 987,
+                    "speech_time" => 188452,
+                    "super_categories" => [
+                        [
+                            "super_category_id" => 2,
+                            "title" => "Hagstjórn"
+                        ]
+                    ],
+                    "document_type" => "stjórnarfrumvarp",
+                    "document_url" => "http=>//www.althingi.is/altext/149/s/0001.html"
+                ],
+                [
+
+                    "assembly" => [
+                        "assembly_id" => 149
+                    ],
+                    "issue" => [
+                        "issue_id" => 20,
+                        "assembly_id" => 149,
+                        "congressman_id" => null,
+                        "category" => "B",
+                        "name" => "nýting fjármuna heilbrigðiskerfisins",
+                        "sub_name" => null,
+                        "type" => "ft",
+                        "type_name" => "óundirbúinn fyrirspurnatími",
+                        "type_subname" => null,
+                        "status" => null,
+                        "question" => null,
+                        "goal" => null,
+                        "major_changes" => null,
+                        "changes_in_law" => null,
+                        "costs_and_revenues" => null,
+                        "deliveries" => null,
+                        "additional_information" => null
+                    ],
+                    "categories" => [ ],
+                    "date" => null,
+                    "government_issue" => false,
+                    "proponents" => [ ],
+                    "speakers" => [
+                        [
+                            "congressman" => [
+                                "congressman_id" => 729,
+                                "name" => "Sigmundur Davíð Gunnlaugsson",
+                                "birth" => "1975-03-12",
+                                "death" => null,
+                                "abbreviation" => "SDG",
+                                "party" => [
+                                    "party_id" => 47,
+                                    "name" => "Miðflokkurinn",
+                                    "abbr_short" => "M",
+                                    "abbr_long" => "Miðfl.",
+                                    "color" => "199094"
+                                ],
+                                "assembly" => null,
+                                "constituency" => [
+                                    "constituency_id" => 49,
+                                    "name" => "Norðausturkjördæmi",
+                                    "abbr_short" => "NA",
+                                    "abbr_long" => "Norðaust.",
+                                    "description" => "Til þess teljast ",
+                                    "date" => "2018-09-11"
+                                ]
+                            ],
+                            "time" => 194
+                        ],
+                        [
+                            "congressman" => [
+                                "congressman_id" => 652,
+                                "name" => "Bjarni Benediktsson",
+                                "birth" => "1970-01-26",
+                                "death" => null,
+                                "abbreviation" => "BjarnB",
+                                "party" => [
+                                    "party_id" => 35,
+                                    "name" => "Sjálfstæðisflokkur",
+                                    "abbr_short" => "S",
+                                    "abbr_long" => "Sjálfstfl.",
+                                    "color" => "00adef"
+                                ],
+                                "assembly" => null,
+                                "constituency" => [
+                                    "constituency_id" => 52,
+                                    "name" => "Suðvesturkjördæmi",
+                                    "abbr_short" => "SV",
+                                    "abbr_long" => "Suðvest.",
+                                    "description" => "Til þess ",
+                                    "date" => "2018-09-11"
+                                ]
+                            ],
+                            "time" => 216
+                        ]
+                    ],
+                    "speech_count" => 4,
+                    "speech_time" => 410,
+                    "super_categories" => [ ]
+                ],
+                [
+
+                    "assembly" => [
+                        "assembly_id" => 150
+                    ],
+                    "issue" => [
+                        "issue_id" => 20,
+                        "assembly_id" => 150,
+                        "congressman_id" => null,
+                        "category" => "B",
+                        "name" => "nýting fjármuna heilbrigðiskerfisins",
+                        "sub_name" => null,
+                        "type" => "ft",
+                        "type_name" => "óundirbúinn fyrirspurnatími",
+                        "type_subname" => null,
+                        "status" => null,
+                        "question" => null,
+                        "goal" => null,
+                        "major_changes" => null,
+                        "changes_in_law" => null,
+                        "costs_and_revenues" => null,
+                        "deliveries" => null,
+                        "additional_information" => null
+                    ],
+                    "categories" => [ ],
+                    "date" => null,
+                    "government_issue" => false,
+                    "proponents" => [ ],
+                    "speakers" => [
+                        [
+                            "congressman" => [
+                                "congressman_id" => 729,
+                                "name" => "Sigmundur Davíð Gunnlaugsson",
+                                "birth" => "1975-03-12",
+                                "death" => null,
+                                "abbreviation" => "SDG",
+                                "party" => [
+                                    "party_id" => 47,
+                                    "name" => "Miðflokkurinn",
+                                    "abbr_short" => "M",
+                                    "abbr_long" => "Miðfl.",
+                                    "color" => "199094"
+                                ],
+                                "assembly" => null,
+                                "constituency" => [
+                                    "constituency_id" => 49,
+                                    "name" => "Norðausturkjördæmi",
+                                    "abbr_short" => "NA",
+                                    "abbr_long" => "Norðaust.",
+                                    "description" => "Til þess teljast ",
+                                    "date" => "2018-09-11"
+                                ]
+                            ],
+                            "time" => 194
+                        ],
+                        [
+                            "congressman" => [
+                                "congressman_id" => 652,
+                                "name" => "Bjarni Benediktsson",
+                                "birth" => "1970-01-26",
+                                "death" => null,
+                                "abbreviation" => "BjarnB",
+                                "party" => [
+                                    "party_id" => 35,
+                                    "name" => "Sjálfstæðisflokkur",
+                                    "abbr_short" => "S",
+                                    "abbr_long" => "Sjálfstfl.",
+                                    "color" => "00adef"
+                                ],
+                                "assembly" => null,
+                                "constituency" => [
+                                    "constituency_id" => 52,
+                                    "name" => "Suðvesturkjördæmi",
+                                    "abbr_short" => "SV",
+                                    "abbr_long" => "Suðvest.",
+                                    "description" => "Til þess ",
+                                    "date" => "2018-09-11"
+                                ]
+                            ],
+                            "time" => 216
+                        ]
+                    ],
+                    "speech_count" => 4,
+                    "speech_time" => 410,
+                    "super_categories" => [ ]
+                ]
+            ]
+        ]);
+
+        return $dataSet;
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,11 +10,11 @@
         <listener class="AlthingiTest\DatabaseSetup" file="./module/Althingi/tests/DatabaseSetup.php" />
     </listeners>
 
-    <!--<filter>-->
-        <!--<whitelist processUncoveredFilesFromWhitelist="true">-->
-            <!--<directory suffix=".php">./module/Althingi/src</directory>-->
-        <!--</whitelist>-->
-    <!--</filter>-->
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./module/Althingi/src</directory>
+        </whitelist>
+    </filter>
 
     <!--<logging>-->
         <!--<log type="coverage-html" target="./assets/docs/tests/report" lowUpperBound="35" highLowerBound="70"/>-->


### PR DESCRIPTION
## What?
Adds tests framework for MongoDB tests

Makes sure that Controller tests don't go to the database

## How?
By going over the Controller tests and make sure that the service/store services are mocked.

Installs a lib that integrates into PHPUnit to do MongoDB tests (writes one test) 

## Why?
So that the controller tests are isolated from the Database.

So that the MongoDB queries can be validated