### PR TITLE
Fetch assemblies from store

### DIFF
--- a/module/Althingi/src/Controller/CabinetController.php
+++ b/module/Althingi/src/Controller/CabinetController.php
@@ -58,6 +58,7 @@ class CabinetController extends AbstractRestfulController implements
      * @output \Althingi\Model\Cabinet[]
      * @query fra
      * @query til
+     * @throws \Exception
      */
     public function getList()
     {
@@ -128,7 +129,7 @@ class CabinetController extends AbstractRestfulController implements
 
     /**
      * @return CollectionModel
-     * $output \Althingi\Model\CabinetProperties[]
+     * @output \Althingi\Model\CabinetProperties[]
      */
     public function assemblyAction()
     {

--- a/module/Althingi/src/Store/Assembly.php
+++ b/module/Althingi/src/Store/Assembly.php
@@ -11,9 +11,13 @@ class Assembly implements StoreAwareInterface
     /** @var \MongoDB\Database */
     private $database;
 
+    /**
+     * @param int $id
+     * @return Model\AssemblyProperties|null
+     */
     public function get(int $id): ?Model\AssemblyProperties
     {
-        $document = $this->getStore()->assembly->findOne([
+        $document = $this->getStore()->selectCollection('assembly')->findOne([
             'assembly.assembly_id' => $id
         ]);
 
@@ -27,6 +31,25 @@ class Assembly implements StoreAwareInterface
             ->setAssembly($assembly);
 
         return $assemblyProperties;
+    }
+
+
+    public function fetch(): array
+    {
+        $document = $this->getStore()->selectCollection('assembly')->find(
+            [],
+            ['sort' => ['assembly.assembly_id' => -1]]
+        );
+
+        if (! $document) {
+            return [];
+        }
+
+        return array_map(function ($assembly) {
+            $assembly = (new Hydrator\Assembly())->hydrate((array) $assembly->assembly, new Model\Assembly());
+            return (new Model\AssemblyProperties())
+                ->setAssembly($assembly);
+        }, $document->toArray());
     }
 
     public function setStore(Database $database)

--- a/module/Althingi/tests/Store/AssemblyTest.php
+++ b/module/Althingi/tests/Store/AssemblyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace AlthingiTest\Store;
+
+use AlthingiTest\StorageConnection;
+use Althingi\Store;
+use Althingi\Model;
+use PHPUnit\Framework\TestCase;
+use Zumba\PHPUnit\Extensions\Mongo\DataSet\DataSet;
+use DateTime;
+
+class AssemblyTest extends TestCase
+{
+    use StorageConnection;
+
+    public function testGet()
+    {
+        $store = (new Store\Assembly())->setStore($this->database);
+        $assembly = $store->get(1);
+
+        $expected = (new Model\AssemblyProperties())
+            ->setAssembly(
+                (new Model\Assembly())
+                    ->setAssemblyId(1)
+                    ->setFrom(new DateTime('2001-01-01'))
+                    ->setTo(new DateTime('2001-01-01'))
+            );
+
+
+        $this->assertEquals($expected, $assembly);
+        $this->assertInstanceOf(Model\AssemblyProperties::class, $assembly);
+    }
+
+    public function testFetch()
+    {
+        $store = (new Store\Assembly())->setStore($this->database);
+        $assembly = $store->fetch();
+
+        $expected = [
+            (new Model\AssemblyProperties())
+                ->setAssembly(
+                    (new Model\Assembly())
+                    ->setAssemblyId(2)
+                    ->setFrom(new DateTime('2001-01-01'))
+                    ->setTo(null)
+                ),
+            (new Model\AssemblyProperties())
+                ->setAssembly(
+                    (new Model\Assembly())
+                    ->setAssemblyId(1)
+                    ->setFrom(new DateTime('2001-01-01'))
+                    ->setTo(new DateTime('2001-01-01'))
+                ),
+            ];
+
+
+        $this->assertEquals($expected, $assembly);
+    }
+
+    /**
+     * Retrieve a DataSet object.
+     *
+     * @return \Zumba\PHPUnit\Extensions\Mongo\DataSet\DataSet
+     */
+    protected function getMongoDataSet()
+    {
+        $dataSet = new DataSet($this->getMongoConnection());
+        $dataSet->setFixture([
+            'assembly' => [
+                [
+                    'assembly' => [
+                        'assembly_id' => 1,
+                        'from' => new \MongoDB\BSON\UTCDateTime(strtotime('2001-01-01') * 1000),
+                        'to' => new \MongoDB\BSON\UTCDateTime(strtotime('2001-01-01') * 1000),
+                    ]
+                ],
+                [
+                    'assembly' => [
+                        'assembly_id' => 2,
+                        'from' => new \MongoDB\BSON\UTCDateTime(strtotime('2001-01-01') * 1000),
+                        'to' => null,
+                    ]
+                ],
+            ]
+        ]);
+
+        return $dataSet;
+    }
+}


### PR DESCRIPTION
## What?
Fetch **Assemblies** from Store

## How?
Implements a **store** for assemblies which queries the MongoDB. This PR also changes the controller to use the store rather than the DB. 

The cabinet and parties are still being fetch through the Database.

## Why?
